### PR TITLE
Add Nexus ready systemd notification option

### DIFF
--- a/Compositor/lib/NexusServer/CMakeLists.txt
+++ b/Compositor/lib/NexusServer/CMakeLists.txt
@@ -12,12 +12,16 @@ option(WPEFRAMEWORK_PLUGIN_COMPOSITOR_BOXMODE "Allows for selecting a boxmode (N
 option(WPEFRAMEWORK_PLUGIN_COMPOSITOR_GRAPHICS_HEAP_SIZE "Change graphic heap of driver (Nexus only).")
 option(WPEFRAMEWORK_PLUGIN_COMPOSITOR_INSTALL_NEXUS_SERVER "Enable to install the server to staging." OFF)
 option(WPEFRAMEWORK_NEXUS_SERVER_HAS_EXTENDED_INIT "Enable to support unauthenticated nxclients." ON)
+option(WPEFRAMEWORK_NEXUS_SERVER_SD_NOTIFY "Enable systemd notification when nexus server is ready." OFF)
 
 message("Setup WPEFramework${TARGET} v${VERSION}...")
 
 find_package(Nexus REQUIRED)
 find_package(NXServer REQUIRED)
 find_package(Core REQUIRED)
+if(WPEFRAMEWORK_NEXUS_SERVER_SD_NOTIFY)
+find_package(Systemd REQUIRED)
+endif()
 
 add_library(${TARGET} STATIC
         NexusServer.cpp
@@ -63,6 +67,23 @@ target_include_directories( ${TARGET}
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         $<INSTALL_INTERFACE:include/${NAMESPACE}>
         )
+
+
+if (WPEFRAMEWORK_NEXUS_SERVER_SD_NOTIFY)
+target_compile_definitions(${TARGET}
+        PRIVATE
+            ${SYSTEMD_DEFINITIONS}
+            NEXUS_SERVER_SD_NOTIFY
+        )
+target_include_directories(${TARGET}
+        PRIVATE
+            ${SYSTEMD_INCLUDE_DIRS}
+        )
+target_link_libraries(${TARGET}
+        PRIVATE
+            ${SYSTEMD_LIBRARIES}
+        )
+endif()
 
 add_library(${NAMESPACE}::${TARGET} ALIAS ${TARGET})
 

--- a/Compositor/lib/NexusServer/NexusServer.cpp
+++ b/Compositor/lib/NexusServer/NexusServer.cpp
@@ -14,6 +14,10 @@
 #include <nexus_display.h>
 #include <sys/stat.h>
 
+#ifdef NEXUS_SERVER_SD_NOTIFY
+#include <systemd/sd-daemon.h>
+#endif
+
 BDBG_MODULE(NexusServer);
 
 namespace WPEFramework {
@@ -394,6 +398,7 @@ namespace Broadcom {
 
                         if (rc == NEXUS_SUCCESS) {
                             TRACE_L1("Created NexusServer[%p].\n", &_instance);
+                            NotifyReady();
                         }
                         else {
                             TRACE_L1("nxserver_ipc_init failed [%d]\n", rc);
@@ -449,6 +454,26 @@ namespace Broadcom {
         if (_stateHandler != nullptr) {
             _stateHandler->StateChange(_state);
         }
+    };
+
+    void Platform::NotifyReady(void)
+    {
+        int rc;
+
+        TRACE_L1("Notify Nexus Server Ready\n");
+#ifdef NEXUS_SERVER_SD_NOTIFY
+        rc = sd_notifyf(0,
+                "READY=1\n"
+                "STATUS=Nexus Server is Ready (from WPE Framework Compositor Plugin)\n"
+                "MAINPID=%lu",
+                getpid());
+        if (rc) {
+            TRACE_L1("Notify Nexus Server Ready to systemd: FAILED (%d)\n", rc);
+        }
+        else {
+            TRACE_L1("Notify Nexus Server Ready to systemd: OK\n");
+        }
+#endif
     };
 
 } // Broadcom

--- a/Compositor/lib/NexusServer/NexusServer.h
+++ b/Compositor/lib/NexusServer/NexusServer.h
@@ -109,6 +109,7 @@ namespace Broadcom {
         void Add(nxclient_t client, const NxClient_JoinSettings* joinSettings);
         void Remove(const char clientName[]);
         void StateChange(server_state state);
+        void NotifyReady(void);
         static void CloseDown();
         static int ClientConnect(nxclient_t client, const NxClient_JoinSettings* pJoinSettings, NEXUS_ClientSettings* pClientSettings);
         static void ClientDisconnect(nxclient_t client, const NxClient_JoinSettings* pJoinSettings);

--- a/cmake/FindSystemd.cmake
+++ b/cmake/FindSystemd.cmake
@@ -1,0 +1,17 @@
+# - Try to find Systemd
+# Once done this will define
+#  SYSTEMD_FOUND - System has libsystemd
+#  SYSTEMD_INCLUDE_DIRS - The libsystemd include directories
+#  SYSTEMD_LIBRARIES - The libraries needed to use libsystemd
+#  SYSTEMD_DEFINITIONS - The libraries needed to use libsystemd
+
+find_package(PkgConfig)
+pkg_check_modules(PC_SYSTEMD QUIET libsystemd)
+
+find_library(SYSTEMD_LIBRARIES NAMES systemd ${PC_SYSTEMD_LIBRARY_DIRS})
+find_path(SYSTEMD_INCLUDE_DIRS systemd/sd-login.h HINTS ${PC_SYSTEMD_INCLUDE_DIRS})
+set(SYSTEMD_DEFINITIONS ${PC_SYSTEMD_CFLAGS_OTHER})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SYSTEMD DEFAULT_MSG SYSTEMD_INCLUDE_DIRS SYSTEMD_LIBRARIES)
+mark_as_advanced(SYSTEMD_FOUND SYSTEMD_INCLUDE_DIRS SYSTEMD_LIBRARIES SYSTEMD_DEFINITIONS)


### PR DESCRIPTION
When the Nexus Server is run by the Compositor Plugin and the WPE
Framework service is brought up via systemd, it is important that the
Nexus Server notifies systemd when it is ready for accepting
connections, so that systemd can wait for this notification before
starting other services that need to connect to Nexus. This is a feature
that is implemented in Broadcom's reference 'nxserver' service (when
it's compiled with the 'ENABLE_SD_NOTIFY' option).

This way, add a new 'WPEFRAMEWORK_NEXUS_SERVER_SD_NOTIFY' option to the
compositor plugin (disabled by default) which, when enabled, performs
the mentioned systemd notification, by using the systemd's library
'sd_notifyf()' function. The notification is done in the new
'Platform::NotifyReady()' method and called right after
'nxserver_ipc_init()' succeeds from 'Platform::Platform()'.

With the new option enabled, there's a new dependency to the systemd
library, so add a new cmake find module ('FindSystemd.cmake') for
making sure the dependency can be satisfied and get the required
elements (includes, libs and definitions).

Signed-off-by: Ricardo Silva <ricardo.silva@gbtembedded.com>