### PR TITLE
[CMAKE] WPEWebKit-2.22 packageconfig file is written as wpe-webkit-0.…

### DIFF
--- a/cmake/FindWPEWebKit.cmake
+++ b/cmake/FindWPEWebKit.cmake
@@ -10,6 +10,7 @@
 
 find_package(PkgConfig)
 pkg_check_modules(PC_WPE_WEBKIT wpe-webkit)
+pkg_check_modules(PC_WPE_WEBKIT wpe-webkit-0.1)
 
 if(PC_WPE_WEBKIT_FOUND)
     if(WPE_WEBKIT_FIND_VERSION AND PC_WPE_WEBKIT_VERSION)


### PR DESCRIPTION
…1.pc and not wpe-webkit.pc. As such add both in the package config check module function so we should find either one of them for backward compatilibity.

Signed-off-by: wouterlucas <wouter@wouterlucas.com>