### PR TITLE
Introduce INotification to Resume clients

### DIFF
--- a/Power/Power.cpp
+++ b/Power/Power.cpp
@@ -31,7 +31,8 @@ static Core::ProxyPoolType<Web::JSONBodyType<Power::Data> > jsonResponseFactory(
 
         // Receive all plugin information on state changes.
         _service->Register(&_sink);
-        
+        _power->Register(&_sink);
+
         _power->Configure(_service->ConfigLine());
 
     } else {
@@ -59,6 +60,8 @@ static Core::ProxyPoolType<Web::JSONBodyType<Power::Data> > jsonResponseFactory(
 
     ASSERT (keyHandler != nullptr);
     keyHandler->Unregister(KEY_POWER, &_sink);
+
+    _power->Unregister(&_sink);
 
     _power = nullptr;
     _service = nullptr;

--- a/Power/Power.h
+++ b/Power/Power.h
@@ -14,7 +14,8 @@ private:
 
     class Notification : 
         public PluginHost::IPlugin::INotification,
-        public PluginHost::VirtualInput::Notifier {
+        public PluginHost::VirtualInput::Notifier,
+        public Exchange::IPower::INotification {
 
     private:
         Notification() = delete;
@@ -41,8 +42,15 @@ private:
         {
             _parent.StateChange(plugin);
         }
+
+        virtual void Resumed()
+        {
+            _parent.ControlClients(Exchange::IPower::PCState::On);
+        }
+
         BEGIN_INTERFACE_MAP(Notification)
             INTERFACE_ENTRY(PluginHost::IPlugin::INotification)
+            INTERFACE_ENTRY(Exchange::IPower::INotification)
         END_INTERFACE_MAP
 
     private:

--- a/Power/PowerImplementation/Stub/PowerImplementation.cpp
+++ b/Power/PowerImplementation/Stub/PowerImplementation.cpp
@@ -42,6 +42,12 @@ public:
     virtual void Configure(const string& settings) {
         TRACE(Trace::Information, (_T("PowerImplementation::Configure()")));
     }
+    virtual void PowerImplementation::Register(Exchange::IPower::INotification* sink) override {
+        TRACE(Trace::Information, (_T("PowerImplementation::Register()")));
+    }
+    virtual void PowerImplementation::Unregister(Exchange::IPower::INotification* sink) override {
+        TRACE(Trace::Information, (_T("PowerImplementation::Unregister()")));
+    }
 
 private:
     PCState _currentState;


### PR DESCRIPTION
Putting clients in suspend mode is linked with Standby Query, but there was no resume call for clients when we awake the system from standby. "Awaking" is handled by platform at the first place, it changes nexus layer from standby to on state but there is no notification mech. to inform power plugin for resume. So we may need to notify Power plugin based on INotification. 

I also updated WpeFramework to introduce IPower::INotification https://github.com/WebPlatformForEmbedded/WPEFramework/tree/odeveci/power_resumed

If this PR is Ok, I will also merge that branch. 

Thanks
Ozgur