### PR TITLE
[Compositor] Support for splitted refsw and nxclient include directories

### DIFF
--- a/cmake/FindNexus.cmake
+++ b/cmake/FindNexus.cmake
@@ -32,6 +32,14 @@
 find_path(LIBNEXUS_INCLUDE nexus_config.h
         PATH_SUFFIXES refsw)
 
+find_path(LIBNXCLIENT_INCLUDE nxserverlib.h
+        PATH_SUFFIXES nxclient refsw)
+
+set(LIBNEXUS_INCLUDE_DIRS
+    ${LIBNEXUS_INCLUDE}
+    ${LIBNXCLIENT_INCLUDE}
+)
+
 find_library(LIBNEXUS_LIBRARY nexus)
 
 find_library(LIBB_OS_LIBRARY b_os)
@@ -44,12 +52,12 @@ find_library(LIBNEXUS_CLIENT_LIBRARY nexus_client)
 
 include(FindPackageHandleStandardArgs)
 
-find_package_handle_standard_args(LIBNEXUS DEFAULT_MSG LIBNEXUS_INCLUDE LIBNEXUS_LIBRARY)
+find_package_handle_standard_args(LIBNEXUS DEFAULT_MSG LIBNEXUS_INCLUDE_DIRS LIBNEXUS_LIBRARY)
 
-mark_as_advanced(LIBNEXUS_INCLUDE LIBNEXUS_LIBRARY)
+mark_as_advanced(LIBNEXUS_INCLUDE_DIRS LIBNEXUS_LIBRARY)
 
 if(EXISTS "${LIBNXCLIENT_LIBRARY}")
-  find_package_handle_standard_args(LIBNXCLIENT DEFAULT_MSG LIBNEXUS_INCLUDE LIBNXCLIENT_LIBRARY)
+  find_package_handle_standard_args(LIBNXCLIENT DEFAULT_MSG LIBNEXUS_INCLUDE_DIRS LIBNXCLIENT_LIBRARY)
   mark_as_advanced(LIBNXCLIENT_LIBRARY)
 endif()
 
@@ -59,7 +67,7 @@ if(NOT TARGET NEXUS::NEXUS)
     if(EXISTS "${LIBNEXUS_LIBRARY}")
         set_target_properties(NEXUS::NEXUS PROPERTIES
                 IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-                INTERFACE_INCLUDE_DIRECTORIES "${LIBNEXUS_INCLUDE}"
+                INTERFACE_INCLUDE_DIRECTORIES "${LIBNEXUS_INCLUDE_DIRS}"
                     )
 
         if(NOT EXISTS "${LIBNEXUS_CLIENT_LIBRARY}")
@@ -95,7 +103,7 @@ if(NOT TARGET NEXUS::NXCLIENT)
         set_target_properties(NEXUS::NXCLIENT PROPERTIES
                 IMPORTED_LINK_INTERFACE_LANGUAGES "C"
                 IMPORTED_LOCATION "${LIBNXCLIENT_LIBRARY}"
-                INTERFACE_INCLUDE_DIRECTORIES "${LIBNEXUS_INCLUDE}"
+                INTERFACE_INCLUDE_DIRECTORIES "${LIBNEXUS_INCLUDE_DIRS}"
                 )
     endif()
 endif()
@@ -106,7 +114,7 @@ if(NOT TARGET NEXUS::NXCLIENT_LOCAL)
         set_target_properties(NEXUS::NXCLIENT_LOCAL PROPERTIES
                 IMPORTED_LINK_INTERFACE_LANGUAGES "C"
                 IMPORTED_LOCATION "${LIBNXCLIENT_LOCAL_LIBRARY}"
-                INTERFACE_INCLUDE_DIRECTORIES "${LIBNEXUS_INCLUDE}"
+                INTERFACE_INCLUDE_DIRECTORIES "${LIBNEXUS_INCLUDE_DIRS}"
                 )
     endif()
 endif()


### PR DESCRIPTION
For Yocto refsw headers are installed in /usr/include/refsw and /usr/include/nxclient. However the current cmake expects (a Buildroot generate install) all headers to be in /usr/include/refsw.
This will result into the following error when building in RDKV/Yocto:
    NexusServer.cpp:418:106: error: 'nxserverlib_init_extended' was not declared in this scope
    |                      _instance = nxserverlib_init_extended(&_serverSettings, config.Authentication.Value());

Updated the cmake to look for both refsw and nxclient subdirs and set the LIBNEXUS_INCLUDE_DIRS accordingly.

Signed-off-by: wouterlucas <wouter@wouterlucas.com>