### PR TITLE
[CMAKE][RemoteControl][RF4CE] Provide an option to disable RF4CE func…

### DIFF
--- a/RemoteControl/CMakeLists.txt
+++ b/RemoteControl/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(PLUGIN_NAME RemoteControl)
 set(MODULE_NAME ${NAMESPACE}${PLUGIN})
 
+option(WPEFRAMEWORK_PLUGIN_REMOTECONTROL_RFCE "Enable RF4CE functionality." ON)
+
 set(WPEFRAMEWORK_PLUGIN_REMOTECONTROL_RFCE_REMOTE_ID "GPSTB" CACHE STRING "User string, used for greenpeak")
 set(WPEFRAMEWORK_PLUGIN_REMOTECONTROL_RFCE_MODULE "/lib/modules/misc/gpK5.ko" CACHE STRING "path to kernel module")
 set(WPEFRAMEWORK_PLUGIN_REMOTECONTROL_RFCE_NODE_ID 249 CACHE STRING "Node ID for the device to be created")
@@ -22,7 +24,10 @@ set_target_properties(${MODULE_NAME} PROPERTIES
 
 find_package(NXServer QUIET)
 find_package(VirtualInput QUIET)
-find_package(RF4CE QUIET)
+
+if(WPEFRAMEWORK_PLUGIN_REMOTECONTROL_RFCE)
+	find_package(RF4CE QUIET)
+endif()
 
 if(VirtualInput_FOUND)
 	message(STATUS "Including VirtualInput support")


### PR DESCRIPTION
…tionality. By default turn on to maintain previous behaviour.

In some cases (e.g. faulty GP unit on a dev-box) it is quite annoying that RF4CE gets enabled by default if the GP bits are found. With the previous functionality I'd have to forcefully remove the RF4CE bits from the staging area in order to get the build to work. Instead, lets do a flag and make it a little easier to turn RF4CE on or off.

Signed-off-by: wouterlucas <wouter@wouterlucas.com>