### PR TITLE
[CMAKE] Use CMAKE_FIND_ROOT_PATH as STAGING_DIR is BR specific and CM…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
 
-include($ENV{STAGING_DIR}${CMAKE_INSTALL_PREFIX}/include/cmake/tools.cmake)
+foreach(searchPath ${CMAKE_FIND_ROOT_PATH})
+    if(EXISTS "${searchPath}/${CMAKE_INSTALL_PREFIX}/include/cmake/tools.cmake")
+        include(${searchPath}/${CMAKE_INSTALL_PREFIX}/include/cmake/tools.cmake)
+    endif()
+endforeach()
 
 option(WPEFRAMEWORK_PLUGIN_BLUETOOTH "Include Bluetooth plugin" OFF)
 option(WPEFRAMEWORK_PLUGIN_COMMANDER "Include Commander plugin" OFF)


### PR DESCRIPTION
…AKE_SYSROOT is not set by Yocto.

Yocto has support for multiple sysroots (native and cross) and as such the CMAKE_SYSROOT can only hold one. Use CMAKE_FIND_ROOT_PATH, as we did before, to find the root paths in the build system. Besides CMAKE_SYSROOT should be used as a value downstream (to the compiler to set --sysroot) not by the build system to find the staging area. As per https://cmake.org/cmake/help/v3.0/variable/CMAKE_SYSROOT.html
Don't blame the buildsystem for silly cmake choices.

Signed-off-by: Wouter-lucas van Boesschoten <wouter@wouterlucas.com>