### PR TITLE
[STREAMER] Some fixes around JSON config generation

### DIFF
--- a/Streamer/Streamer.config
+++ b/Streamer/Streamer.config
@@ -10,6 +10,7 @@ map()
     end()
     kv(frontends ${PLUGIN_STREAMER_FRONTENDS})
     kv(decoders ${PLUGIN_STREAMER_DECODERS})
+    if("${STREAMER_IMPLEMENTATION}" STREQUAL "QAM")
     if(PLUGIN_STREAMER_HOME_TS)
         # unfortunately the %$^%#$$% CMAKE is a big mess AGAIN !!!
         # The logical steps to get the 
@@ -23,6 +24,6 @@ map()
     kv(annex C)
     endif()
     kv(scan true)
-    
+    endif()
 end()
 ans(configuration)

--- a/Streamer/Streamer.config
+++ b/Streamer/Streamer.config
@@ -15,7 +15,7 @@ map()
         # The logical steps to get the 
         kv(homets "Please fill in manually CMAKE $%#^^$ UP..... again !!!")
     endif(PLUGIN_STREAMER_HOME_TS)
-    if( ${PLUGIN_STREAMER_STANDARD} STREQUAL "DVB")
+    if("${PLUGIN_STREAMER_STANDARD}" STREQUAL "DVB")
     kv(standard DVB)
     kv(annex A)
     else()


### PR DESCRIPTION
Some fixes and improvements around the automatic generation of the JSON config for the Streamer Plugin.

Commit 1 fixes a cmake syntax error when PLUGIN_STREAMER_STANDARD variable is not set.  
Commit 2 is for adding QAM related configs only when the selected implementation is indeed set to QAM.