### PR TITLE
fixing undefined reference to g_bus_get_sync in Bluetooth Plugin

### DIFF
--- a/Bluetooth/CMakeLists.txt
+++ b/Bluetooth/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
 
 message("Setting up ${PLUGIN_NAME}")
 
-find_package(GLIB REQUIRED)
+find_package(GLIB REQUIRED COMPONENTS gio)
 find_package(DBUS REQUIRED)
 
 set(PLUGIN_SOURCES


### PR DESCRIPTION
WPEFramework fails to start when Bluetooth plugin is enabled because of
the undefined reference to libgio function (ie g_bus_get_sync). This
will link libgio-2.0 to the Bluetooth plugin.