### PR TITLE
WifiControl Plugin : PUT config operation hangs

### DIFF
--- a/WifiControl/Controller.h
+++ b/WifiControl/Controller.h
@@ -945,6 +945,8 @@ public:
         EnabledContainer::iterator entry (_enabled.find(SSID));
 
         if (entry != _enabled.end()) {
+             //Config call internally calls Lock so unlocking here to avoid dead lock
+	     _adminLock.Unlock();
             // This is an existing config. Easy Piecie.
             result = Config (Core::ProxyType<Controller>(*this), SSID);
         }
@@ -971,10 +973,10 @@ public:
             _adminLock.Lock();
 
             _enabled[SSID] = ConfigInfo(id, false);
+	    //Config internally calls Lock so unlocking here to avoid dead lock
+	    _adminLock.Unlock();
             result = Config(Core::ProxyType<Controller>(*this), SSID);
         }
-
-        _adminLock.Unlock();
   
         return (result);
     }


### PR DESCRIPTION
This commit will fix bug in wificontrol plugin config put operation
The hang was cause due improper use of synchronization lock mechanism
in the code.
GetKey API internally tries to acquire the lock which is already acquired
by put method which results in hang. Put method and GetKey are in two
different thread.
Test Steps:

Put a configuration:
curl -d '{"ssid":"SSID", "psk":"***", "key":"WPA"}' -v -H "Content-Type: application/json" -v -X PUT http://ip:8082/Service/WifiControl/Config