### PR TITLE
[CMAKE] Avoid --as-needed flag on OCDM plugin, in some cases this wil…

### DIFF
--- a/OpenCDMi/CMakeLists.txt
+++ b/OpenCDMi/CMakeLists.txt
@@ -11,6 +11,10 @@ set(PLUGIN_SOURCES
 
 find_package(ocdm REQUIRED)
 
+# avoid -as-needed flag being set, this will break linking to libocdm.so
+string(REPLACE "-Wl,--as-needed" "" CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-as-needed")
+
 # Library definition section
 add_library(${MODULE_NAME} SHARED ${PLUGIN_SOURCES})
 target_link_libraries(${MODULE_NAME} ${PLUGINS_LIBRARIES} ${OCDM_LIBRARIES})


### PR DESCRIPTION
…l omit linking to libocdm.so and the setup wont work. By explicitly adding --no-as-needed this will alway be linked correctly.