### PR TITLE
Config POST and DELETE operation hangs

### DIFF
--- a/WifiControl/Controller.h
+++ b/WifiControl/Controller.h
@@ -1142,7 +1142,7 @@ public:
 
         if ( (index != _enabled.end()) && (index->second.IsEnabled() == true) ) {
 
-            CustomRequest exchange (string(_TXT("DISCONNECT ")) + Core::NumberType<uint32_t>(index->second.Id()).Text());
+            CustomRequest exchange (string(_TXT("DISCONNECT")));
 
             Submit(&exchange);
 

--- a/WifiControl/Controller.h
+++ b/WifiControl/Controller.h
@@ -929,10 +929,13 @@ public:
 
         if (entry != _enabled.end()) {
             // This is an existing config. Easy Piecie.
+            //Config call internally calls Lock so unlocking here to avoid dead lock
+            _adminLock.Unlock();
             result = Config (Core::ProxyType<Controller>(*this), SSID);
         }
-
-        _adminLock.Unlock();
+        else{
+            _adminLock.Unlock();
+        }
   
         return (result);
     }
@@ -991,8 +994,10 @@ public:
         if ( (entry != _enabled.end()) && (entry->second.Id() != 0) ) {
 
             // This is an existing config. Easy Piecie.
+	    //Config internally calls Lock so unlocking here to avoid dead lock
+            _adminLock.Unlock();
             result = Config (Core::ProxyType<Controller>(*this), SSID);
-
+            _adminLock.Lock();
             // We have bo entry for this SSID, lets create one.
             CustomRequest exchange (string(_TXT("REMOVE_NETWORK ")) + Core::NumberType<uint32_t>(entry->second.Id()).Text());
 


### PR DESCRIPTION
This commit will fix bug in wificontrol plugin configuration
post and delete operation. The hang was caused due to
the improper use of synchronization lock mechanism in the code.

GetKey API internally tries to acquire the lock which is already
acquired by post|delete methods called, which results in hang.
post|delete methods.

Test Steps:

Add a configuration :
curl -d '{"ssid":"SSID", "psk":"**", "key":"WPA"}' -v -H "Content-Type:
application/json" -v -X PUT http://ip:8082/Service/WifiControl/Config

Update a configuration:
curl -d '{"ssid":"SSID", "psk":"**", "key":"WPA"}' -v -H "Content-Type:
application/json" -v -X POST http://ip:8082/Service/WifiControl/Config

Delete a configuration:
curl -X DELETE -v http://127.0.0.1:8082/Service/WifiControl/Config/SSID