### PR TITLE
[TestUtility] Add TestUtility plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(PLUGIN_REMOTECONTROL "Include RemoteControl plugin" OFF)
 option(PLUGIN_STREAMER "Include Streamer plugin" OFF)
 option(PLUGIN_SNAPSHOT "Include Snapshot plugin" OFF)
 option(PLUGIN_SYSTEMCOMMANDS "Include SystemCommands plugin" OFF)
+option(PLUGIN_TESTUTILITY "Include TestUtility plugin" OFF)
 option(PLUGIN_TIMESYNC "Include TimeSync plugin" OFF)
 option(PLUGIN_TRACECONTROL "Include TraceControl plugin" OFF)
 option(PLUGIN_WEBKITBROWSER "Include WebKitBrowser plugin" OFF)
@@ -124,6 +125,10 @@ endif()
 
 if(PLUGIN_SYSTEMDCONNECTOR)
     add_subdirectory(SystemdConnector)
+endif()
+
+if(PLUGIN_TESTUTILITY)
+    add_subdirectory(TestUtility)
 endif()
 
 if(PLUGIN_TIMESYNC)

--- a/TestUtility/CMakeLists.txt
+++ b/TestUtility/CMakeLists.txt
@@ -1,0 +1,31 @@
+set(PLUGIN_NAME TestUtility)
+set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
+
+message("Setting up ${PLUGIN_NAME}")
+
+find_package(${NAMESPACE}Plugins REQUIRED)
+
+add_library(${MODULE_NAME} SHARED
+        Module.cpp
+        TestUtility.cpp
+        TestUtilityImp.cpp
+        CommandCore/TestCommandController.cpp
+        Commands/Malloc.cpp
+        Commands/Free.cpp
+        Commands/Statm.cpp
+        Commands/Crash.cpp
+        Commands/CrashNTimes.cpp
+)
+
+set_target_properties(${MODULE_NAME} PROPERTIES
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED YES)
+
+target_link_libraries(${MODULE_NAME}
+    PRIVATE
+        ${NAMESPACE}Plugins::${NAMESPACE}Plugins)
+
+install(TARGETS ${MODULE_NAME}
+    DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
+
+write_config(${PLUGIN_NAME})

--- a/TestUtility/CommandCore/TestCommandBase.h
+++ b/TestUtility/CommandCore/TestCommandBase.h
@@ -1,0 +1,101 @@
+#include "TestCommandMetadata.h"
+#include "interfaces/ITestUtility.h"
+
+#include "../Module.h"
+
+namespace WPEFramework {
+
+class TestCommandBase : public Exchange::ITestUtility::ICommand {
+    public:
+        class SignatureBuilder {
+            public:
+                SignatureBuilder(const SignatureBuilder&) = delete;
+                SignatureBuilder& operator=(const SignatureBuilder&) = delete;
+
+                explicit SignatureBuilder(const TestCore::TestCommandSignature::Parameter& returnParam)
+                    : _jsonSignature()
+                {
+                    _jsonSignature.Output = returnParam;
+
+                }
+
+                SignatureBuilder& InputParameter(const TestCore::TestCommandSignature::Parameter& inputParam)
+                {
+                    _jsonSignature.Input.Add(inputParam);
+
+                    return (*this);
+                }
+
+                virtual ~SignatureBuilder() = default;
+
+            private:
+
+                friend class TestCommandBase;
+                string ToString() const
+                {
+                    string outString;
+                    _jsonSignature.ToString(outString);
+
+                    return outString;
+                }
+
+                TestCore::TestCommandSignature _jsonSignature;
+        };
+
+        class DescriptionBuilder {
+            public:
+                DescriptionBuilder(const DescriptionBuilder&) = delete;
+                DescriptionBuilder& operator=(const DescriptionBuilder&) = delete;
+
+                explicit DescriptionBuilder(const string& description)
+                    : _jsonDescription()
+                {
+                    _jsonDescription.Description = description;
+                }
+
+                virtual ~DescriptionBuilder() = default;
+
+            private:
+
+                friend class TestCommandBase;
+                string ToString() const
+                {
+                    string outString;
+                    _jsonDescription.ToString(outString);
+
+                    return outString;
+                }
+
+                TestCore::TestCommandDescription _jsonDescription;
+        };
+
+    private:
+        TestCommandBase(const TestCommandBase&) = delete;
+        TestCommandBase& operator=(const TestCommandBase&) = delete;
+
+    public:
+        explicit TestCommandBase(const DescriptionBuilder& description, const SignatureBuilder& signature)
+            : Exchange::ITestUtility::ICommand()
+            , _description(description.ToString())
+            , _signature(signature.ToString())
+        { }
+
+        virtual ~TestCommandBase() = default;
+
+    public:
+        // ICommand methods
+        string Description() const final
+        {
+            return _description;
+        }
+
+        string Signature() const final
+        {
+            return _signature;
+        }
+
+    private:
+        string _description;
+        string _signature;
+};
+} // namespace WPEFramework

--- a/TestUtility/CommandCore/TestCommandBase.h
+++ b/TestUtility/CommandCore/TestCommandBase.h
@@ -7,8 +7,13 @@ namespace WPEFramework {
 
 class TestCommandBase : public Exchange::ITestUtility::ICommand {
     public:
+        TestCommandBase() = delete;
+        TestCommandBase(const TestCommandBase&) = delete;
+        TestCommandBase& operator=(const TestCommandBase&) = delete;
+
+    public:
         class SignatureBuilder {
-            private:
+            public:
                 SignatureBuilder() = delete;
                 SignatureBuilder(const SignatureBuilder&) = delete;
                 SignatureBuilder& operator=(const SignatureBuilder&) = delete;
@@ -45,7 +50,7 @@ class TestCommandBase : public Exchange::ITestUtility::ICommand {
         };
 
         class DescriptionBuilder {
-            private:
+            public:
                 DescriptionBuilder() = delete;
                 DescriptionBuilder(const DescriptionBuilder&) = delete;
                 DescriptionBuilder& operator=(const DescriptionBuilder&) = delete;
@@ -72,11 +77,6 @@ class TestCommandBase : public Exchange::ITestUtility::ICommand {
 
                 TestCore::TestCommandDescription _jsonDescription;
         };
-
-    private:
-        TestCommandBase() = delete;
-        TestCommandBase(const TestCommandBase&) = delete;
-        TestCommandBase& operator=(const TestCommandBase&) = delete;
 
     public:
         explicit TestCommandBase(const DescriptionBuilder& description, const SignatureBuilder& signature)

--- a/TestUtility/CommandCore/TestCommandBase.h
+++ b/TestUtility/CommandCore/TestCommandBase.h
@@ -8,10 +8,12 @@ namespace WPEFramework {
 class TestCommandBase : public Exchange::ITestUtility::ICommand {
     public:
         class SignatureBuilder {
-            public:
+            private:
+                SignatureBuilder() = delete;
                 SignatureBuilder(const SignatureBuilder&) = delete;
                 SignatureBuilder& operator=(const SignatureBuilder&) = delete;
 
+            public:
                 explicit SignatureBuilder(const TestCore::TestCommandSignature::Parameter& returnParam)
                     : _jsonSignature()
                 {
@@ -43,10 +45,12 @@ class TestCommandBase : public Exchange::ITestUtility::ICommand {
         };
 
         class DescriptionBuilder {
-            public:
+            private:
+                DescriptionBuilder() = delete;
                 DescriptionBuilder(const DescriptionBuilder&) = delete;
                 DescriptionBuilder& operator=(const DescriptionBuilder&) = delete;
 
+            public:
                 explicit DescriptionBuilder(const string& description)
                     : _jsonDescription()
                 {
@@ -70,6 +74,7 @@ class TestCommandBase : public Exchange::ITestUtility::ICommand {
         };
 
     private:
+        TestCommandBase() = delete;
         TestCommandBase(const TestCommandBase&) = delete;
         TestCommandBase& operator=(const TestCommandBase&) = delete;
 

--- a/TestUtility/CommandCore/TestCommandController.cpp
+++ b/TestUtility/CommandCore/TestCommandController.cpp
@@ -14,7 +14,8 @@ void TestCommandController::Announce(Exchange::ITestUtility::ICommand* command)
     ASSERT(command != nullptr);
 
     _adminLock.Lock();
-    _commands[command->Name()] = command;
+    std::pair<TestCommandContainer::iterator, bool> returned = _commands.insert(TestCommandContainerPair(command->Name(), command));
+    ASSERT((returned.second == true) && "Test command already exists!");
     _adminLock.Unlock();
 }
 

--- a/TestUtility/CommandCore/TestCommandController.cpp
+++ b/TestUtility/CommandCore/TestCommandController.cpp
@@ -1,0 +1,59 @@
+#include "TestCommandController.h"
+
+namespace WPEFramework {
+namespace TestCore {
+
+/* static */ TestCommandController& TestCommandController::Instance()
+{
+    static TestCommandController _singleton;
+    return (_singleton);
+}
+
+void TestCommandController::Announce(Exchange::ITestUtility::ICommand* command)
+{
+    ASSERT(command != nullptr);
+
+    _adminLock.Lock();
+    _commands[command->Name()] = command;
+    _adminLock.Unlock();
+}
+
+void TestCommandController::Revoke(Exchange::ITestUtility::ICommand* command)
+{
+    ASSERT(command != nullptr);
+
+    _adminLock.Lock();
+    _commands.erase(command->Name());
+    _adminLock.Unlock();
+}
+
+Exchange::ITestUtility::ICommand* TestCommandController::Command(const string& name)
+{
+    Exchange::ITestUtility::ICommand* command = nullptr;
+
+    _adminLock.Lock();
+    Exchange::ITestUtility::ICommand::IIterator* iter = Commands();
+
+    while (iter->Next())
+    {
+        if (iter->Command()->Name() == name)
+        {
+            command = iter->Command();
+            break;
+        }
+    }
+    _adminLock.Unlock();
+
+    return command;
+}
+
+Exchange::ITestUtility::ICommand::IIterator* TestCommandController::Commands(void) const
+{
+    Exchange::ITestUtility::ICommand::IIterator* iterator = nullptr;
+    _adminLock.Lock();
+    iterator = Core::Service<Iterator>::Create<Exchange::ITestUtility::ICommand::IIterator>(_commands);
+    _adminLock.Unlock();
+    return iterator;
+}
+} // namespace TestCore
+} // namespace WPEFramework

--- a/TestUtility/CommandCore/TestCommandController.h
+++ b/TestUtility/CommandCore/TestCommandController.h
@@ -9,12 +9,20 @@ namespace TestCore {
 
 class TestCommandController
 {
+    public:
+        TestCommandController(const TestCommandController&) = delete;
+        TestCommandController& operator=(const TestCommandController&) = delete;
+
     private:
         using TestCommandContainer = std::map<string, Exchange::ITestUtility::ICommand*>;
         using TestCommandContainerPair = std::pair<string, Exchange::ITestUtility::ICommand*>;
 
         class Iterator : public Exchange::ITestUtility::ICommand::IIterator
         {
+            public:
+                Iterator(const Iterator&) = delete;
+                Iterator& operator= (const Iterator&) = delete;
+
             public:
                 using IteratorImpl = Core::IteratorMapType<TestCommandContainer, Exchange::ITestUtility::ICommand*, string>;
 
@@ -24,9 +32,6 @@ class TestCommandController
                     , _iterator(_container) { }
 
                 virtual ~Iterator() = default;
-
-                Iterator(const Iterator&) = delete;
-                Iterator& operator= (const Iterator&) = delete;
 
                 BEGIN_INTERFACE_MAP(Iterator)
                     INTERFACE_ENTRY(Exchange::ITestUtility::ICommand::IIterator)
@@ -53,8 +58,6 @@ class TestCommandController
                     IteratorImpl _iterator;
         };
 
-        TestCommandController(const TestCommandController&) = delete;
-        TestCommandController& operator=(const TestCommandController&) = delete;
         TestCommandController()
             : _adminLock()
             , _commands()

--- a/TestUtility/CommandCore/TestCommandController.h
+++ b/TestUtility/CommandCore/TestCommandController.h
@@ -11,6 +11,7 @@ class TestCommandController
 {
     private:
         using TestCommandContainer = std::map<string, Exchange::ITestUtility::ICommand*>;
+        using TestCommandContainerPair = std::pair<string, Exchange::ITestUtility::ICommand*>;
 
         class Iterator : public Exchange::ITestUtility::ICommand::IIterator
         {

--- a/TestUtility/CommandCore/TestCommandController.h
+++ b/TestUtility/CommandCore/TestCommandController.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "../Module.h"
+
+#include <interfaces/ITestUtility.h>
+
+namespace WPEFramework {
+namespace TestCore {
+
+class TestCommandController
+{
+    private:
+        using TestCommandContainer = std::map<string, Exchange::ITestUtility::ICommand*>;
+
+        class Iterator : public Exchange::ITestUtility::ICommand::IIterator
+        {
+            public:
+                using IteratorImpl = Core::IteratorMapType<TestCommandContainer, Exchange::ITestUtility::ICommand*, string>;
+
+                explicit Iterator(const TestCommandContainer& commands)
+                    : Exchange::ITestUtility::ICommand::IIterator()
+                    , _container(commands)
+                    , _iterator(_container) { }
+
+                virtual ~Iterator() = default;
+
+                Iterator(const Iterator&) = delete;
+                Iterator& operator= (const Iterator&) = delete;
+
+                BEGIN_INTERFACE_MAP(Iterator)
+                    INTERFACE_ENTRY(Exchange::ITestUtility::ICommand::IIterator)
+                END_INTERFACE_MAP
+
+                void Reset() override {
+                    _iterator.Reset(0);
+                }
+
+                bool IsValid() const override {
+                    return _iterator.IsValid();
+                }
+
+                bool Next() override {
+                    return _iterator.Next();
+                }
+
+                Exchange::ITestUtility::ICommand* Command() const override {
+                    return *_iterator;
+                }
+
+                private:
+                    TestCommandContainer _container;
+                    IteratorImpl _iterator;
+        };
+
+        TestCommandController(const TestCommandController&) = delete;
+        TestCommandController& operator=(const TestCommandController&) = delete;
+        TestCommandController()
+            : _adminLock()
+            , _commands()
+        {
+        }
+
+    public:
+        static TestCommandController& Instance();
+        ~TestCommandController() = default;
+
+        // ITestUtility methods
+        Exchange::ITestUtility::ICommand* Command(const string& name);
+        Exchange::ITestUtility::ICommand::IIterator* Commands(void) const;
+
+        // TestCommandController methods
+        void Announce(Exchange::ITestUtility::ICommand* command);
+        void Revoke(Exchange::ITestUtility::ICommand* command);
+
+    private:
+        mutable Core::CriticalSection _adminLock;
+        TestCommandContainer _commands;
+};
+} // namespace TestCore
+} // namespace WPEFramework

--- a/TestUtility/CommandCore/TestCommandMetadata.h
+++ b/TestUtility/CommandCore/TestCommandMetadata.h
@@ -1,0 +1,162 @@
+#pragma once
+
+#include "../Module.h"
+
+namespace WPEFramework {
+namespace TestCore {
+
+class TestCommandDescription : public Core::JSON::Container {
+private:
+    TestCommandDescription(const TestCommandDescription&) = delete;
+    TestCommandDescription& operator=(const TestCommandDescription&) = delete;
+
+public:
+    TestCommandDescription()
+        : Core::JSON::Container()
+        , Description()
+    {
+        Add(_T("description"), &Description);
+    }
+
+    ~TestCommandDescription() = default;
+
+public:
+    Core::JSON::String Description;
+};
+
+class TestCommandName : public Core::JSON::Container {
+private:
+    TestCommandName(const TestCommandName&) = delete;
+    TestCommandName& operator=(const TestCommandName&) = delete;
+
+public:
+    TestCommandName()
+        : Core::JSON::Container()
+        , Name()
+    {
+        Add(_T("name"), &Name);
+    }
+
+    ~TestCommandName() = default;
+
+public:
+    Core::JSON::String Name;
+};
+
+class TestCommandSignature : public Core::JSON::Container {
+private:
+    TestCommandSignature(const TestCommandSignature&) = delete;
+    TestCommandSignature& operator=(const TestCommandSignature&) = delete;
+
+public:
+    class Parameter : public Core::JSON::Container {
+    public:
+        enum class JSType : uint8_t
+        {
+            NUMBER = 0,
+            STRING,
+            BOOLEAN,
+            OBJECT,
+            SYMBOL
+        };
+
+        string ParamTypeToString(const JSType& type)
+        {
+            switch(type)
+            {
+                case JSType::NUMBER: return _T("Number");
+                case JSType::STRING: return _T("String");
+                case JSType::BOOLEAN: return _T("Boolean");
+                case JSType::OBJECT: return _T("Object");
+                case JSType::SYMBOL: return _T("Symbol");
+                default: return _T("Undefined");
+            };
+        }
+
+    public:
+        Parameter()
+            : Core::JSON::Container()
+            , Name()
+            , Type()
+            , Comment()
+
+        {
+            AddFields();
+        }
+
+        Parameter(const string& name, const JSType& type, const string& comment)
+            : Core::JSON::Container()
+            , Name()
+            , Type()
+            , Comment()
+        {
+            // currently there is something wrong with the copy constructor of Core::JSON::String
+            // for example: invoking ToString() will not generate proper string
+            // that's why we want to copy elements using opertor=
+            this->Name = name;
+            this->Type = ParamTypeToString(type);
+            this->Comment = comment;
+
+            AddFields();
+        }
+
+        Parameter(const Parameter& copy)
+            : Core::JSON::Container()
+            , Name()
+            , Type()
+            , Comment()
+        {
+            // currently there is something wrong with the copy constructor of Core::JSON::String
+            // for example: invoking ToString() will not generate proper string
+            // that's why we want to copy elements using opertor=
+            this->Name = copy.Name;
+            this->Type = copy.Type;
+            this->Comment = copy.Comment;
+
+            AddFields();
+        }
+
+        Parameter& operator=(const Parameter& rhs)
+        {
+            this->Name = rhs.Name;
+            this->Type = rhs.Type;
+            this->Comment = rhs.Comment;
+
+            return *this;
+        }
+
+        ~Parameter() = default;
+
+    private:
+        inline void AddFields()
+        {
+            Add(_T("name"), &Name);
+            Add(_T("type"), &Type);
+            Add(_T("comment"), &Comment);
+        }
+
+    public:
+        Core::JSON::String Name;
+        Core::JSON::String Type;
+        Core::JSON::String Comment;
+    };
+
+public:
+    TestCommandSignature()
+        : Core::JSON::Container()
+        , Input()
+        , Output()
+    {
+        Add(_T("input"), &Input);
+        Add(_T("output"), &Output);
+    }
+
+    ~TestCommandSignature() = default;
+
+public:
+    Core::JSON::ArrayType<Parameter> Input;
+    Parameter Output;
+};
+
+} // namespace TestCore
+} // namespace WPEFramework

--- a/TestUtility/CommandCore/TestCommandMetadata.h
+++ b/TestUtility/CommandCore/TestCommandMetadata.h
@@ -6,7 +6,7 @@ namespace WPEFramework {
 namespace TestCore {
 
 class TestCommandDescription : public Core::JSON::Container {
-private:
+public:
     TestCommandDescription(const TestCommandDescription&) = delete;
     TestCommandDescription& operator=(const TestCommandDescription&) = delete;
 
@@ -25,7 +25,7 @@ public:
 };
 
 class TestCommandName : public Core::JSON::Container {
-private:
+public:
     TestCommandName(const TestCommandName&) = delete;
     TestCommandName& operator=(const TestCommandName&) = delete;
 

--- a/TestUtility/CommandCore/TraceCategories.h
+++ b/TestUtility/CommandCore/TraceCategories.h
@@ -4,7 +4,7 @@ namespace WPEFramework {
 namespace TestCore {
 
 class TestLifeCycle {
-    private:
+    public:
         TestLifeCycle() = delete;
         TestLifeCycle(const TestLifeCycle& a_Copy) = delete;
         TestLifeCycle& operator=(const TestLifeCycle& a_RHS) = delete;
@@ -32,7 +32,7 @@ class TestLifeCycle {
     };
 
     class TestOutput {
-    private:
+    public:
         TestOutput() = delete;
         TestOutput(const TestOutput& a_Copy) = delete;
         TestOutput& operator=(const TestOutput& a_RHS) = delete;

--- a/TestUtility/CommandCore/TraceCategories.h
+++ b/TestUtility/CommandCore/TraceCategories.h
@@ -1,0 +1,63 @@
+#pragma once
+
+namespace WPEFramework {
+namespace TestCore {
+
+class TestLifeCycle {
+    private:
+        TestLifeCycle() = delete;
+        TestLifeCycle(const TestLifeCycle& a_Copy) = delete;
+        TestLifeCycle& operator=(const TestLifeCycle& a_RHS) = delete;
+
+    public:
+        TestLifeCycle(const TCHAR formatter[], ...)
+        {
+            va_list ap;
+            va_start(ap, formatter);
+            Trace::Format(_text, formatter, ap);
+            va_end(ap);
+        }
+        explicit TestLifeCycle(const string& text)
+            : _text(Core::ToString(text))
+        {
+        }
+        ~TestLifeCycle() = default;
+
+    public:
+        inline const char* Data() const { return (_text.c_str()); }
+        inline uint16_t Length() const { return (static_cast<uint16_t>(_text.length())); }
+
+    private:
+        std::string _text;
+    };
+
+    class TestOutput {
+    private:
+        TestOutput() = delete;
+        TestOutput(const TestOutput& a_Copy) = delete;
+        TestOutput& operator=(const TestOutput& a_RHS) = delete;
+
+    public:
+        TestOutput(const TCHAR formatter[], ...)
+        {
+            va_list ap;
+            va_start(ap, formatter);
+            Trace::Format(_text, formatter, ap);
+            va_end(ap);
+        }
+        explicit TestOutput(const string& text)
+            : _text(Core::ToString(text))
+        {
+        }
+        ~TestOutput() = default;
+
+    public:
+        inline const char* Data() const { return (_text.c_str()); }
+        inline uint16_t Length() const { return (static_cast<uint16_t>(_text.length())); }
+
+    private:
+        std::string _text;
+};
+
+} // namespace TestCore
+} // namespace WPEFramework

--- a/TestUtility/Commands/Crash.cpp
+++ b/TestUtility/Commands/Crash.cpp
@@ -6,7 +6,7 @@
 namespace WPEFramework {
 
 class Crash : public TestCommandBase {
-private:
+public:
     Crash(const Crash&) = delete;
     Crash& operator=(const Crash&) = delete;
 
@@ -32,7 +32,7 @@ public:
 
 private:
     class CrashInputMetadata : public Core::JSON::Container {
-    private:
+    public:
         CrashInputMetadata(const CrashInputMetadata&) = delete;
         CrashInputMetadata& operator=(const CrashInputMetadata&) = delete;
 

--- a/TestUtility/Commands/Crash.cpp
+++ b/TestUtility/Commands/Crash.cpp
@@ -1,0 +1,78 @@
+#include "../CommandCore/TestCommandBase.h"
+#include "../CommandCore/TestCommandController.h"
+
+#include "CrashCore.h"
+
+namespace WPEFramework {
+
+class Crash : public TestCommandBase {
+private:
+    Crash(const Crash&) = delete;
+    Crash& operator=(const Crash&) = delete;
+
+public:
+    using Parameter = TestCore::TestCommandSignature::Parameter;
+
+    Crash()
+        : TestCommandBase(
+            TestCommandBase::DescriptionBuilder(_T("Cause segmenation fault resulting in crash")),
+            TestCommandBase::SignatureBuilder(Parameter())
+                .InputParameter(Parameter("crashDelay", Parameter::JSType::NUMBER, "delay in ms before actual crash")))
+        , _crashCore(CrashCore::Instance())
+        , _name(_T("Crash"))
+    {
+        TestCore::TestCommandController::Instance().Announce(this);
+    }
+
+    virtual ~Crash() { TestCore::TestCommandController::Instance().Revoke(this); }
+
+    BEGIN_INTERFACE_MAP(Crash)
+    INTERFACE_ENTRY(Exchange::ITestUtility::ICommand)
+    END_INTERFACE_MAP
+
+private:
+    class CrashInputMetadata : public Core::JSON::Container {
+    private:
+        CrashInputMetadata(const CrashInputMetadata&) = delete;
+        CrashInputMetadata& operator=(const CrashInputMetadata&) = delete;
+
+    public:
+        CrashInputMetadata()
+            : Core::JSON::Container()
+            , CrashDelay(0)
+        {
+            Add(_T("crashDelay"), &CrashDelay);
+        }
+        ~CrashInputMetadata() = default;
+
+    public:
+        Core::JSON::DecUInt8 CrashDelay;
+    };
+
+public:
+    virtual string /*JSON*/ Execute(const string& params) final
+    {
+        CrashInputMetadata input;
+        uint8_t crashDelay = CrashCore::DefaultCrashDelay;
+        string responseString = _T("");
+
+        if (input.FromString(params))
+        {
+            crashDelay = input.CrashDelay;
+        }
+
+        responseString = _crashCore.Crash(crashDelay);
+
+        return (_crashCore.ErrorResponse(responseString));
+    }
+
+    virtual string Name() const final { return _name; }
+
+private:
+    CrashCore& _crashCore;
+    string _name;
+};
+
+static Crash* _singleton(Core::Service<Crash>::Create<Crash>());
+
+} // namespace WPEFramework

--- a/TestUtility/Commands/CrashCore.h
+++ b/TestUtility/Commands/CrashCore.h
@@ -1,0 +1,191 @@
+#pragma once
+
+#include "../Module.h"
+
+#include "../CommandCore/TraceCategories.h"
+#include <fstream>
+
+namespace WPEFramework {
+
+class CrashCore {
+private:
+    CrashCore(const CrashCore&) = delete;
+    CrashCore& operator=(const CrashCore&) = delete;
+
+public:
+    static constexpr const uint8_t DefaultCrashDelay = 3;
+    static constexpr const char* PendingCrashFilepath = "/tmp/CrashCore.pending";
+
+public:
+    // ToDo: maybe error response should be generic and moved to TestCore
+    class ErrorRes : public Core::JSON::Container {
+    private:
+        ErrorRes(const ErrorRes&) = delete;
+        ErrorRes& operator=(const ErrorRes&) = delete;
+
+    public:
+        ErrorRes()
+            : Core::JSON::Container()
+            , ErrorMsg()
+        {
+            Add(_T("errorMsg"), &ErrorMsg);
+        }
+
+        ~ErrorRes() = default;
+
+    public:
+        Core::JSON::String ErrorMsg;
+    };
+
+public:
+    CrashCore()
+        : _lock()
+    {
+    }
+
+    virtual ~CrashCore() = default;
+
+    static CrashCore& Instance()
+    {
+        static CrashCore _singleton;
+        return (_singleton);
+    }
+
+    string Crash(const uint8_t crashDelay) const
+    {
+        string response = EMPTY_STRING;
+
+        TRACE(TestCore::TestOutput, (_T("Executing crash in %d seconds"), crashDelay));
+        sleep(crashDelay);
+
+        uint8_t* tmp = nullptr;
+        *tmp = 3; // segmentaion fault
+
+        response = _T("Function should never return");
+
+        return response;
+    }
+
+    string CrashNTimes(const uint8_t crashCount)
+    {
+        string response = EMPTY_STRING;
+
+        uint8_t pendingCrashCount = PendingCrashCount();
+        if (pendingCrashCount != 0)
+        {
+            response = _T("Pending crash already in progress");
+        }
+        else
+        {
+            if (!SetPendingCrashCount(crashCount))
+            {
+                response = _T("Failed to set new pending crash count");
+            }
+            else
+            {
+                ExecPendingCrash();
+            }
+        }
+
+        return response;
+    }
+
+    string ExecPendingCrash(void)
+    {
+        string response = _T("");
+        uint8_t pendingCrashCount = PendingCrashCount();
+        if (pendingCrashCount > 0)
+        {
+            pendingCrashCount--;
+            if (SetPendingCrashCount(pendingCrashCount))
+            {
+                response = Crash(DefaultCrashDelay);
+            }
+            else
+            {
+                response = _T("Failed to set new pending crash count");
+                TRACE(TestCore::TestOutput, ("%s", response.c_str()));
+            }
+        }
+        else
+        {
+            response = _T("No pending crash");
+            TRACE(TestCore::TestOutput, ("%s", response.c_str()));
+        }
+
+        return response;
+    }
+
+    // ToDo: maybe error response should be generic and moved to TestCore
+    string ErrorResponse(const string& message) const
+    {
+        ErrorRes responseJSON;
+        string responseString = _T("");
+
+        if (!message.empty())
+        {
+            responseJSON.ErrorMsg = message;
+            responseJSON.ToString(responseString);
+        }
+
+        return responseString;
+    }
+
+private:
+    uint8_t PendingCrashCount(void) const
+    {
+        uint8_t pendingCrashCount = 0;
+        std::ifstream pendingCrashFile;
+
+        _lock.Lock();
+        pendingCrashFile.open(PendingCrashFilepath, std::fstream::binary);
+        if (pendingCrashFile.is_open())
+        {
+            uint8_t readVal = 0;
+
+            pendingCrashFile >> readVal;
+            if (pendingCrashFile.good())
+            {
+                pendingCrashCount = readVal;
+            }
+            else
+            {
+                TRACE(TestCore::TestOutput, (_T("Failed to read value from pendingCrashFile")));
+            }
+        }
+        _lock.Unlock();
+
+        return pendingCrashCount;
+    }
+
+    bool SetPendingCrashCount(const uint8_t newCrashCount)
+    {
+        bool status = false;
+        std::ofstream pendingCrashFile;
+
+        _lock.Lock();
+        pendingCrashFile.open(PendingCrashFilepath, std::fstream::binary | std::fstream::trunc);
+        if (pendingCrashFile.is_open())
+        {
+            pendingCrashFile << newCrashCount;
+
+            if (pendingCrashFile.good())
+            {
+                status = true;
+            }
+            else
+            {
+                TRACE(TestCore::TestOutput, (_T("Failed to write value to pendingCrashFile ")));
+            }
+            pendingCrashFile.close();
+        }
+        _lock.Unlock();
+
+        return status;
+    }
+
+private:
+    mutable Core::CriticalSection _lock;
+};
+
+} // namespace WPEFramework

--- a/TestUtility/Commands/CrashCore.h
+++ b/TestUtility/Commands/CrashCore.h
@@ -8,7 +8,7 @@
 namespace WPEFramework {
 
 class CrashCore {
-private:
+public:
     CrashCore(const CrashCore&) = delete;
     CrashCore& operator=(const CrashCore&) = delete;
 
@@ -19,7 +19,7 @@ public:
 public:
     // ToDo: maybe error response should be generic and moved to TestCore
     class ErrorRes : public Core::JSON::Container {
-    private:
+    public:
         ErrorRes(const ErrorRes&) = delete;
         ErrorRes& operator=(const ErrorRes&) = delete;
 

--- a/TestUtility/Commands/CrashNTimes.cpp
+++ b/TestUtility/Commands/CrashNTimes.cpp
@@ -1,0 +1,87 @@
+#include "../CommandCore/TestCommandBase.h"
+#include "../CommandCore/TestCommandController.h"
+
+#include "CrashCore.h"
+
+namespace WPEFramework {
+
+class CrashNTimes : public TestCommandBase {
+private:
+    CrashNTimes(const CrashNTimes&) = delete;
+    CrashNTimes& operator=(const CrashNTimes&) = delete;
+
+public:
+    using Parameter = TestCore::TestCommandSignature::Parameter;
+
+    CrashNTimes()
+        : TestCommandBase(TestCommandBase::DescriptionBuilder(_T("Cause segmenation fault N times in a row")),
+              TestCommandBase::SignatureBuilder(Parameter())
+                  .InputParameter(Parameter("crashCount", Parameter::JSType::NUMBER, "how many times Crash will be executed consecutively")))
+        , _crashCore(CrashCore::Instance())
+        , _name(_T("CrashNTimes"))
+    {
+        TestCore::TestCommandController::Instance().Announce(this);
+
+        _crashCore.ExecPendingCrash();
+    }
+
+    virtual ~CrashNTimes() { TestCore::TestCommandController::Instance().Revoke(this); }
+
+    BEGIN_INTERFACE_MAP(CrashNTimes)
+    INTERFACE_ENTRY(Exchange::ITestUtility::ICommand)
+    END_INTERFACE_MAP
+
+private:
+    class CrashNTimesInputMetadata : public Core::JSON::Container {
+    private:
+        CrashNTimesInputMetadata(const CrashNTimesInputMetadata&) = delete;
+        CrashNTimesInputMetadata& operator=(const CrashNTimesInputMetadata&) = delete;
+
+    public:
+        CrashNTimesInputMetadata()
+            : Core::JSON::Container()
+            , CrashCount(0)
+        {
+            Add(_T("crashCount"), &CrashCount);
+        }
+
+        ~CrashNTimesInputMetadata() = default;
+
+    public:
+        Core::JSON::DecUInt8 CrashCount;
+    };
+
+public:
+    virtual string Execute(const string& params) final
+    {
+        CrashNTimesInputMetadata input;
+        string responseString = _T("");
+        uint8_t crashCount = 0;
+
+        if (input.FromString(params))
+        {
+            crashCount = input.CrashCount;
+        }
+
+        if (crashCount > 0)
+        {
+            responseString = _crashCore.CrashNTimes(crashCount);
+        }
+        else
+        {
+            responseString = _T("crashCount must be greater than 0");
+        }
+
+        return (_crashCore.ErrorResponse(responseString));
+    }
+
+    virtual string Name() const final { return _name; }
+
+private:
+    CrashCore& _crashCore;
+    string _name;
+};
+
+static CrashNTimes* _singleton(Core::Service<CrashNTimes>::Create<CrashNTimes>());
+
+} // namespace WPEFramework

--- a/TestUtility/Commands/CrashNTimes.cpp
+++ b/TestUtility/Commands/CrashNTimes.cpp
@@ -6,7 +6,7 @@
 namespace WPEFramework {
 
 class CrashNTimes : public TestCommandBase {
-private:
+public:
     CrashNTimes(const CrashNTimes&) = delete;
     CrashNTimes& operator=(const CrashNTimes&) = delete;
 
@@ -33,7 +33,7 @@ public:
 
 private:
     class CrashNTimesInputMetadata : public Core::JSON::Container {
-    private:
+    public:
         CrashNTimesInputMetadata(const CrashNTimesInputMetadata&) = delete;
         CrashNTimesInputMetadata& operator=(const CrashNTimesInputMetadata&) = delete;
 

--- a/TestUtility/Commands/Free.cpp
+++ b/TestUtility/Commands/Free.cpp
@@ -1,0 +1,53 @@
+#include "../CommandCore/TestCommandController.h"
+#include "../CommandCore/TestCommandBase.h"
+#include "MemoryAllocation.h"
+
+namespace WPEFramework {
+
+class Free : public TestCommandBase {
+    private:
+        Free(const Free&) = delete;
+        Free& operator=(const Free&) = delete;
+
+    public:
+        using Parameter = TestCore::TestCommandSignature::Parameter;
+
+        Free()
+            : TestCommandBase(TestCommandBase::DescriptionBuilder("Releases previously allocated memory"),
+                              TestCommandBase::SignatureBuilder(Parameter("memory", Parameter::JSType::NUMBER, "memory statistics in KB")))
+            , _memoryAdmin(MemoryAllocation::Instance())
+        {
+            TestCore::TestCommandController::Instance().Announce(this);
+        }
+
+        virtual ~Free()
+        {
+            TestCore::TestCommandController::Instance().Revoke(this);
+        }
+
+    public:
+        // ICommand methods
+        string Execute(const string& params) final
+        {
+            bool status = _memoryAdmin.Free();
+            return (status == true ? _memoryAdmin.CreateResponse() : EMPTY_STRING);
+        }
+
+        string Name() const final
+        {
+            return _name;
+        }
+
+    private:
+        BEGIN_INTERFACE_MAP(Free)
+            INTERFACE_ENTRY(Exchange::ITestUtility::ICommand)
+        END_INTERFACE_MAP
+
+    private:
+        MemoryAllocation& _memoryAdmin;
+        const string _name = _T("Free");
+};
+
+static Free* _singleton(Core::Service<Free>::Create<Free>());
+
+} // namespace WPEFramework

--- a/TestUtility/Commands/Free.cpp
+++ b/TestUtility/Commands/Free.cpp
@@ -5,7 +5,7 @@
 namespace WPEFramework {
 
 class Free : public TestCommandBase {
-    private:
+    public:
         Free(const Free&) = delete;
         Free& operator=(const Free&) = delete;
 

--- a/TestUtility/Commands/Malloc.cpp
+++ b/TestUtility/Commands/Malloc.cpp
@@ -5,9 +5,13 @@
 namespace WPEFramework {
 
 class Malloc : public TestCommandBase {
+    public:
+        Malloc(const Malloc&) = delete;
+        Malloc& operator=(const Malloc&) = delete;
+
     private:
         class MallocInputMetadata : public Core::JSON::Container {
-            private:
+            public:
                 MallocInputMetadata(const MallocInputMetadata&) = delete;
                 MallocInputMetadata& operator=(const MallocInputMetadata&) = delete;
 
@@ -23,9 +27,6 @@ class Malloc : public TestCommandBase {
             public:
                 Core::JSON::DecSInt32 Size;
         };
-
-        Malloc(const Malloc&) = delete;
-        Malloc& operator=(const Malloc&) = delete;
 
     public:
         using Parameter = TestCore::TestCommandSignature::Parameter;

--- a/TestUtility/Commands/Malloc.cpp
+++ b/TestUtility/Commands/Malloc.cpp
@@ -1,0 +1,79 @@
+#include "../CommandCore/TestCommandController.h"
+#include "../CommandCore/TestCommandBase.h"
+#include "MemoryAllocation.h"
+
+namespace WPEFramework {
+
+class Malloc : public TestCommandBase {
+    private:
+        class MallocInputMetadata : public Core::JSON::Container {
+            private:
+                MallocInputMetadata(const MallocInputMetadata&) = delete;
+                MallocInputMetadata& operator=(const MallocInputMetadata&) = delete;
+
+            public:
+                MallocInputMetadata()
+                    : Core::JSON::Container()
+                    , Size(0)
+                {
+                    Add(_T("size"), &Size);
+                }
+                ~MallocInputMetadata() = default;
+
+            public:
+                Core::JSON::DecSInt32 Size;
+        };
+
+        Malloc(const Malloc&) = delete;
+        Malloc& operator=(const Malloc&) = delete;
+
+    public:
+        using Parameter = TestCore::TestCommandSignature::Parameter;
+
+        Malloc()
+            : TestCommandBase(TestCommandBase::DescriptionBuilder("Allocates desired kB in memory and holds it"),
+                              TestCommandBase::SignatureBuilder(Parameter("memory", Parameter::JSType::NUMBER, "memory statistics in KB"))
+                              .InputParameter(Parameter("size", Parameter::JSType::NUMBER, "memory in kB for allocation")))
+            , _memoryAdmin(MemoryAllocation::Instance())
+        {
+            TestCore::TestCommandController::Instance().Announce(this);
+        }
+
+        virtual ~Malloc()
+        {
+            TestCore::TestCommandController::Instance().Revoke(this);
+        }
+
+    public:
+        // ICommand methods
+        string Execute(const string& params) final
+        {
+            MallocInputMetadata input;
+            uint32_t size;
+
+            if (input.FromString(params))
+            {
+                size = input.Size;
+                _memoryAdmin.Malloc(size);
+            }
+            return _memoryAdmin.CreateResponse();
+        }
+
+        string Name() const final
+        {
+            return _name;
+        }
+
+    private:
+        BEGIN_INTERFACE_MAP(Malloc)
+            INTERFACE_ENTRY(Exchange::ITestUtility::ICommand)
+        END_INTERFACE_MAP
+
+    private:
+        MemoryAllocation& _memoryAdmin;
+        const string _name = _T("Malloc");
+};
+
+static Malloc* _singleton(Core::Service<Malloc>::Create<Malloc>());
+
+} // namespace WPEFramework

--- a/TestUtility/Commands/MemoryAllocation.h
+++ b/TestUtility/Commands/MemoryAllocation.h
@@ -5,6 +5,10 @@
 namespace WPEFramework {
 
 class MemoryAllocation {
+    public:
+        MemoryAllocation(const MemoryAllocation&) = delete;
+        MemoryAllocation& operator=(const MemoryAllocation&) = delete;
+
     private:
         class MemoryOutputMetadata : public Core::JSON::Container {
         private:
@@ -28,9 +32,6 @@ class MemoryAllocation {
             Core::JSON::DecSInt32 Size;
             Core::JSON::DecSInt32 Resident;
         };
-
-        MemoryAllocation(const MemoryAllocation&) = delete;
-        MemoryAllocation& operator=(const MemoryAllocation&) = delete;
 
         MemoryAllocation()
             : _lock()

--- a/TestUtility/Commands/MemoryAllocation.h
+++ b/TestUtility/Commands/MemoryAllocation.h
@@ -1,0 +1,158 @@
+#pragma once
+
+#include "../Module.h"
+
+namespace WPEFramework {
+
+class MemoryAllocation {
+    private:
+        class MemoryOutputMetadata : public Core::JSON::Container {
+        private:
+            MemoryOutputMetadata(const MemoryOutputMetadata&) = delete;
+            MemoryOutputMetadata& operator=(const MemoryOutputMetadata&) = delete;
+        public:
+            MemoryOutputMetadata()
+                : Core::JSON::Container()
+                , Allocated(0)
+                , Size(0)
+                , Resident(0)
+                {
+                    Add(_T("allocated"), &Allocated);
+                    Add(_T("size"), &Size);
+                    Add(_T("resident"), &Resident);
+                }
+            ~MemoryOutputMetadata() = default;
+
+        public:
+            Core::JSON::DecSInt32 Allocated;
+            Core::JSON::DecSInt32 Size;
+            Core::JSON::DecSInt32 Resident;
+        };
+
+        MemoryAllocation(const MemoryAllocation&) = delete;
+        MemoryAllocation& operator=(const MemoryAllocation&) = delete;
+
+        MemoryAllocation()
+            : _lock()
+            , _process()
+            , _startSize(0)
+            , _startResident(0)
+            , _currentMemoryAllocation(0)
+            , _memory()
+        {
+            DisableOOMKill();
+            _startSize = static_cast<uint32_t>(_process.Allocated() >> 10);
+            _startResident = static_cast<uint32_t>(_process.Resident() >> 10);
+        }
+
+    public:
+        static MemoryAllocation& Instance()
+        {
+            static MemoryAllocation _singleton;
+            return (_singleton);
+        }
+
+        ~MemoryAllocation() = default;
+
+    public:
+        // Memory Allocation methods
+        void Malloc(uint32_t size) // size in Kb
+        {
+            uint32_t noOfBlocks = 0;
+            uint32_t blockSize = (32 * (getpagesize() >> 10)); // 128kB block size
+            uint32_t runs = (uint32_t)size / blockSize;
+
+            _lock.Lock();
+            for (noOfBlocks = 0; noOfBlocks < runs; ++noOfBlocks)
+            {
+                _memory.push_back(malloc(static_cast<size_t>(blockSize << 10)));
+                if (!_memory.back())
+                {
+                    SYSLOG(Trace::Fatal, (_T("*** Failed allocation !!! ***")));
+                    break;
+                }
+
+                for (uint32_t index = 0; index < (blockSize << 10); index++)
+                {
+                    static_cast<unsigned char*>(_memory.back())[index] = static_cast<unsigned char>(rand() & 0xFF);
+                }
+            }
+            _currentMemoryAllocation += (noOfBlocks * blockSize);
+            _lock.Unlock();
+        }
+
+        bool Free(void)
+        {
+            bool status = false;
+
+            if (!_memory.empty())
+            {
+                for (auto const& memoryBlock : _memory)
+                {
+                    free(memoryBlock);
+                }
+                _memory.clear();
+                status = true;
+            }
+
+            _lock.Lock();
+            _currentMemoryAllocation = 0;
+            _lock.Unlock();
+
+            return status;
+        }
+
+        void Statm(uint32_t &allocated, uint32_t &size, uint32_t &resident)
+        {
+            _lock.Lock();
+            allocated = _currentMemoryAllocation;
+            _lock.Unlock();
+
+            size = static_cast<uint32_t>(_process.Allocated() >> 10);
+            resident = static_cast<uint32_t>(_process.Resident() >> 10);
+
+            LogMemoryUsage();
+        }
+
+        string /*JSON*/ CreateResponse()
+        {
+            string jsonResponse = EMPTY_STRING;
+
+            MemoryOutputMetadata response;
+            uint32_t allocated, size, resident;
+
+            Statm(allocated, size, resident);
+
+            response.Allocated = allocated;
+            response.Resident = resident;
+            response.Size = size;
+            response.ToString(jsonResponse);
+
+            return jsonResponse;
+        }
+
+    private:
+        void DisableOOMKill(void)
+        {
+            int8_t oomNo = -17;
+            _process.OOMAdjust(oomNo);
+        }
+
+        void LogMemoryUsage(void)
+        {
+            SYSLOG(Trace::Information, (_T("*** Current allocated: %lu Kb ***"), _currentMemoryAllocation));
+            SYSLOG(Trace::Information, (_T("*** Initial Size:     %lu Kb ***"), _startSize));
+            SYSLOG(Trace::Information, (_T("*** Initial Resident: %lu Kb ***"), _startResident));
+            SYSLOG(Trace::Information, (_T("*** Size:     %lu Kb ***"), static_cast<uint32_t>(_process.Allocated() >> 10)));
+            SYSLOG(Trace::Information, (_T("*** Resident: %lu Kb ***"), static_cast<uint32_t>(_process.Resident() >> 10)));
+        }
+
+    private:
+        Core::CriticalSection _lock;
+        Core::ProcessInfo _process;
+        uint32_t _startSize;
+        uint32_t _startResident;
+        uint32_t _currentMemoryAllocation; // size in Kb
+        std::list<void*> _memory;
+};
+} // namespace WPEFramework

--- a/TestUtility/Commands/Statm.cpp
+++ b/TestUtility/Commands/Statm.cpp
@@ -5,7 +5,7 @@
 namespace WPEFramework {
 
 class Statm : public TestCommandBase {
-    private:
+    public:
         Statm(const Statm&) = delete;
         Statm& operator=(const Statm&) = delete;
 

--- a/TestUtility/Commands/Statm.cpp
+++ b/TestUtility/Commands/Statm.cpp
@@ -1,0 +1,52 @@
+#include "../CommandCore/TestCommandController.h"
+#include "../CommandCore/TestCommandBase.h"
+#include "MemoryAllocation.h"
+
+namespace WPEFramework {
+
+class Statm : public TestCommandBase {
+    private:
+        Statm(const Statm&) = delete;
+        Statm& operator=(const Statm&) = delete;
+
+    public:
+        using Parameter = TestCore::TestCommandSignature::Parameter;
+
+        Statm()
+            : TestCommandBase(TestCommandBase::DescriptionBuilder("Provides information about system memory allocation"),
+                              TestCommandBase::SignatureBuilder(Parameter("memory", Parameter::JSType::NUMBER, "memory statistics in KB")))
+            , _memoryAdmin(MemoryAllocation::Instance())
+        {
+            TestCore::TestCommandController::Instance().Announce(this);
+        }
+
+        virtual ~Statm()
+        {
+            TestCore::TestCommandController::Instance().Revoke(this);
+        }
+
+    public:
+        // ICommand methods
+        string Execute(const string& params) final
+        {
+            return _memoryAdmin.CreateResponse();
+        }
+
+        string Name() const final
+        {
+            return _name;
+        }
+
+    private:
+        BEGIN_INTERFACE_MAP(Statm)
+            INTERFACE_ENTRY(Exchange::ITestUtility::ICommand)
+        END_INTERFACE_MAP
+
+    private:
+        MemoryAllocation& _memoryAdmin;
+        const string _name = _T("Statm");
+};
+
+static Statm* _singleton(Core::Service<Statm>::Create<Statm>());
+
+} // namespace WPEFramework

--- a/TestUtility/Module.cpp
+++ b/TestUtility/Module.cpp
@@ -1,0 +1,3 @@
+#include "Module.h"
+
+MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/TestUtility/Module.h
+++ b/TestUtility/Module.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#ifndef MODULE_NAME
+#define MODULE_NAME Plugin_TestUtility
+#endif
+
+#include <plugins/plugins.h>
+
+#undef EXTERNAL
+#define EXTERNAL

--- a/TestUtility/TestUtility.config
+++ b/TestUtility/TestUtility.config
@@ -1,0 +1,9 @@
+set (autostart true)
+
+map()
+    key(root)
+    map()
+      kv(outofprocess true)
+    end()
+end()
+ans(configuration)

--- a/TestUtility/TestUtility.cpp
+++ b/TestUtility/TestUtility.cpp
@@ -60,7 +60,6 @@ SERVICE_REGISTRATION(TestUtility, 1, 0);
 
 /* virtual */ const string TestUtility::Initialize(PluginHost::IShell* service)
 {
-    /*Assume that everything is OK*/
     string message = EMPTY_STRING;
 
     ASSERT(service != nullptr);
@@ -99,11 +98,13 @@ SERVICE_REGISTRATION(TestUtility, 1, 0);
     ASSERT(_service == service);
     ASSERT(_testUtilityImp != nullptr);
     ASSERT(_memory != nullptr);
-    ASSERT(_pid);
 
-    TRACE(Trace::Information, (_T("*** OutOfProcess Plugin is properly destructed. PID: %d ***"), _pid))
+    if (_testUtilityImp->Release() != Core::ERROR_DESTRUCTION_SUCCEEDED)
+    {
+        TRACE(Trace::Information, (_T("TestUtility is not properly destructed (pid=%d)"), _pid));
+        ProcessTermination(_pid);
+    }
 
-    ProcessTermination(_pid);
     _testUtilityImp = nullptr;
     _memory->Release();
     _memory = nullptr;

--- a/TestUtility/TestUtility.cpp
+++ b/TestUtility/TestUtility.cpp
@@ -1,0 +1,271 @@
+#include "TestUtility.h"
+
+namespace WPEFramework {
+namespace TestUtility {
+
+Exchange::IMemory* MemoryObserver(const uint32_t pid)
+{
+    class MemoryObserverImpl : public Exchange::IMemory {
+    private:
+        MemoryObserverImpl();
+        MemoryObserverImpl(const MemoryObserverImpl&);
+        MemoryObserverImpl& operator=(const MemoryObserverImpl&);
+
+    public:
+        MemoryObserverImpl(const uint32_t id)
+            : _main(id == 0 ? Core::ProcessInfo().Id() : id)
+            , _observable(false)
+        {
+        }
+        ~MemoryObserverImpl() = default;
+
+    public:
+        virtual void Observe(const uint32_t pid)
+        {
+            if (pid == 0)
+            {
+                _observable = false;
+            }
+            else
+            {
+                _observable = true;
+                _main = Core::ProcessInfo(pid);
+            }
+        }
+        virtual uint64_t Resident() const { return (_observable == false ? 0 : _main.Resident()); }
+
+        virtual uint64_t Allocated() const { return (_observable == false ? 0 : _main.Allocated()); }
+
+        virtual uint64_t Shared() const { return (_observable == false ? 0 : _main.Shared()); }
+
+        virtual uint8_t Processes() const { return (IsOperational() ? 1 : 0); }
+
+        virtual const bool IsOperational() const { return (_observable == false) || (_main.IsActive()); }
+
+        BEGIN_INTERFACE_MAP(MemoryObserverImpl)
+        INTERFACE_ENTRY(Exchange::IMemory)
+        END_INTERFACE_MAP
+
+    private:
+        Core::ProcessInfo _main;
+        bool _observable;
+    };
+
+    return (Core::Service<MemoryObserverImpl>::Create<Exchange::IMemory>(pid));
+}
+} // namespace TestUtility
+
+namespace Plugin {
+SERVICE_REGISTRATION(TestUtility, 1, 0);
+
+/* virtual */ const string TestUtility::Initialize(PluginHost::IShell* service)
+{
+    /*Assume that everything is OK*/
+    string message = EMPTY_STRING;
+
+    ASSERT(service != nullptr);
+    ASSERT(_service == nullptr);
+    ASSERT(_testUtilityImp == nullptr);
+    ASSERT(_memory == nullptr);
+
+    _service = service;
+    _skipURL = static_cast<uint8_t>(_service->WebPrefix().length());
+    _service->Register(&_notification);
+
+    _testUtilityImp = _service->Root<Exchange::ITestUtility>(_pid, ImplWaitTime, _T("TestUtilityImp"));
+
+    if ((_testUtilityImp != nullptr) && (_service != nullptr))
+    {
+        _memory = WPEFramework::TestUtility::MemoryObserver(_pid);
+        ASSERT(_memory != nullptr);
+        _memory->Observe(_pid);
+    }
+    else
+    {
+        ProcessTermination(_pid);
+        _service = nullptr;
+        _testUtilityImp = nullptr;
+        _service->Unregister(&_notification);
+
+        TRACE(Trace::Fatal, (_T("*** TestUtility could not be instantiated ***")))
+        message = _T("TestUtility could not be instantiated.");
+    }
+
+    return message;
+}
+
+/* virtual */ void TestUtility::Deinitialize(PluginHost::IShell* service)
+{
+    ASSERT(_service == service);
+    ASSERT(_testUtilityImp != nullptr);
+    ASSERT(_memory != nullptr);
+    ASSERT(_pid);
+
+    TRACE(Trace::Information, (_T("*** OutOfProcess Plugin is properly destructed. PID: %d ***"), _pid))
+
+    ProcessTermination(_pid);
+    _testUtilityImp = nullptr;
+    _memory->Release();
+    _memory = nullptr;
+    _service->Unregister(&_notification);
+    _service = nullptr;
+}
+
+/* virtual */ string TestUtility::Information() const
+{
+    // No additional info to report.
+    return ((_T("The purpose of this plugin is provide ability to execute functional tests.")));
+}
+
+static Core::ProxyPoolType<Web::TextBody> _testUtilityMetadata(2);
+
+/* virtual */ void TestUtility::Inbound(Web::Request& request)
+{
+    if ((request.Verb == Web::Request::HTTP_POST) || (request.Verb == Web::Request::HTTP_PUT))
+    {
+        request.Body(_testUtilityMetadata.Element());
+    }
+}
+
+/* virtual */ Core::ProxyType<Web::Response> TestUtility::Process(const Web::Request& request)
+{
+    ASSERT(_skipURL <= request.Path.length());
+    Core::ProxyType<Web::Response> result(PluginHost::Factories::Instance().Response());
+
+    if (_testUtilityImp != nullptr)
+    {
+        Core::ProxyType<Web::TextBody> body(_testUtilityMetadata.Element());
+        string requestBody = EMPTY_STRING;
+
+        if (((request.Verb == Web::Request::HTTP_POST) || (request.Verb == Web::Request::HTTP_PUT)) && (request.HasBody()))
+        {
+            requestBody = (*request.Body<Web::TextBody>());
+        }
+
+        (*body) = HandleRequest(request.Verb, request.Path, _skipURL, requestBody);
+        if((*body) != EMPTY_STRING)
+        {
+            result->Body<Web::TextBody>(body);
+            result->ErrorCode = Web::STATUS_OK;
+            result->Message = (_T("OK"));
+            result->ContentType = Web::MIMETypes::MIME_JSON;
+        }
+        else
+        {
+            result->ErrorCode = Web::STATUS_BAD_REQUEST;
+            result->Message = (_T("Method is not supported"));
+        }
+    }
+    else
+    {
+        result->ErrorCode = Web::STATUS_METHOD_NOT_ALLOWED;
+        result->Message = (_T("Test controller does not exist"));
+    }
+    return result;
+}
+
+void TestUtility::ProcessTermination(uint32_t pid)
+{
+    RPC::IRemoteProcess* process(_service->RemoteProcess(pid));
+    if (process != nullptr)
+    {
+        process->Terminate();
+        process->Release();
+    }
+}
+
+void TestUtility::Activated(RPC::IRemoteProcess* /*process*/)
+{
+    return;
+}
+
+void TestUtility::Deactivated(RPC::IRemoteProcess* process)
+{
+    if (_pid == process->Id())
+    {
+        ASSERT(_service != nullptr);
+        PluginHost::WorkerPool::Instance().Submit(PluginHost::IShell::Job::Create(_service, PluginHost::IShell::DEACTIVATED, PluginHost::IShell::FAILURE));
+    }
+}
+
+string /*JSON*/ TestUtility::TestCommands(void)
+{
+    string response = EMPTY_STRING;
+    Metadata testCommands;
+
+    Exchange::ITestUtility::ICommand::IIterator* supportedCommands = _testUtilityImp->Commands();
+    ASSERT(supportedCommands != nullptr);
+
+    while (supportedCommands->Next())
+    {
+        Core::JSON::String name;
+        name = supportedCommands->Command()->Name();
+        testCommands.TestCommands.Add(name);
+    }
+    testCommands.ToString(response);
+
+    return response;
+}
+
+string /*JSON*/ TestUtility::HandleRequest(Web::Request::type type, const string& path, const uint8_t skipUrl, const string& body /*JSON*/)
+{
+    bool executed = false;
+    // Return empty result in case of issue
+    string /*JSON*/ response = EMPTY_STRING;
+
+    Core::TextSegmentIterator index(Core::TextFragment(path, skipUrl, path.length() - skipUrl), false, '/');
+
+    index.Next();
+    index.Next();
+    // Here process request other than:
+    // /Service/<CALLSIGN>/TestCommands
+    // /Service/<CALLSIGN>/<TEST_COMMAND_NAME>/...
+
+    if (index.Current().Text() == _T("TestCommands"))
+    {
+        if ((!index.Next()) && (type == Web::Request::HTTP_GET))
+        {
+            response = TestCommands();
+            executed = true;
+        }
+    }
+    else
+    {
+        Exchange::ITestUtility::ICommand *command = _testUtilityImp->Command(index.Current().Text());
+
+        if (command)
+        {
+            if (!index.Next() && ((type == Web::Request::HTTP_POST) || (type == Web::Request::HTTP_PUT)))
+            {
+                // Execute test command
+                response = command->Execute(body);
+                executed = true;
+            }
+            else
+            {
+                if (type == Web::Request::HTTP_GET)
+                {
+                    if ((index.Current().Text() == _T("Description")) && (!index.Next()))
+                    {
+                        response = command->Description();
+                        executed = true;
+                    }
+                    else if ((index.Current().Text() == _T("Parameters")) && (!index.Next()))
+                    {
+                        response = command->Signature();
+                        executed = true;
+                    }
+                }
+            }
+        }
+    }
+
+    if (!executed)
+    {
+        TRACE(Trace::Fatal, (_T("*** Test case method not found !!! ***")))
+    }
+
+    return response;
+}
+} // namespace Plugin
+} // namespace WPEFramework

--- a/TestUtility/TestUtility.h
+++ b/TestUtility/TestUtility.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include "Module.h"
+
+#include "CommandCore/TestCommandController.h"
+#include <interfaces/IMemory.h>
+#include <interfaces/ITestUtility.h>
+
+namespace WPEFramework {
+namespace Plugin {
+
+class TestUtility : public PluginHost::IPlugin, public PluginHost::IWeb {
+public:
+    // maximum wait time for process to be spawned
+    static constexpr uint32_t ImplWaitTime = 1000;
+
+private:
+    class Notification : public RPC::IRemoteProcess::INotification {
+    private:
+        Notification() = delete;
+        Notification(const Notification&) = delete;
+
+    public:
+        explicit Notification(TestUtility* parent)
+            : _parent(*parent)
+        {
+            ASSERT(parent != nullptr);
+        }
+        virtual ~Notification() = default;
+
+    public:
+        virtual void Activated(RPC::IRemoteProcess* process) { _parent.Activated(process); }
+
+        virtual void Deactivated(RPC::IRemoteProcess* process) { _parent.Deactivated(process); }
+
+        BEGIN_INTERFACE_MAP(Notification)
+        INTERFACE_ENTRY(RPC::IRemoteProcess::INotification)
+        END_INTERFACE_MAP
+
+    private:
+        TestUtility& _parent;
+    };
+
+    class Metadata : public Core::JSON::Container {
+        private:
+            Metadata(const Metadata&) = delete;
+            Metadata& operator=(const Metadata&) = delete;
+
+        public:
+            Metadata()
+                : Core::JSON::Container()
+                , TestCommands()
+            {
+                Add(_T("testCommands"), &TestCommands);
+            }
+            ~Metadata() = default;
+
+        public:
+            Core::JSON::ArrayType<Core::JSON::String> TestCommands;
+    };
+
+public:
+    TestUtility()
+        : _service(nullptr)
+        , _notification(this)
+        , _memory(nullptr)
+        , _testUtilityImp(nullptr)
+        , _skipURL(0)
+        , _pid(0)
+    {
+    }
+
+    virtual ~TestUtility() = default;
+
+    BEGIN_INTERFACE_MAP(TestUtility)
+        INTERFACE_ENTRY(PluginHost::IPlugin)
+        INTERFACE_ENTRY(PluginHost::IWeb)
+        INTERFACE_AGGREGATE(Exchange::IMemory, _memory)
+        INTERFACE_AGGREGATE(Exchange::ITestUtility, _testUtilityImp)
+    END_INTERFACE_MAP
+
+    //   IPlugin methods
+    // -------------------------------------------------------------------------------------------------------
+    virtual const string Initialize(PluginHost::IShell* service) override;
+    virtual void Deinitialize(PluginHost::IShell* service) override;
+    virtual string Information() const override;
+
+    //  IWeb methods
+    // -------------------------------------------------------------------------------------------------------
+    virtual void Inbound(Web::Request& request);
+    virtual Core::ProxyType<Web::Response> Process(const Web::Request& request);
+
+private:
+    TestUtility(const TestUtility&) = delete;
+    TestUtility& operator=(const TestUtility&) = delete;
+
+    void Activated(RPC::IRemoteProcess* process);
+    void Deactivated(RPC::IRemoteProcess* process);
+
+    void ProcessTermination(uint32_t pid);
+    string /*JSON*/ HandleRequest(Web::Request::type type, const string& path, const uint8_t skipUrl, const string& body /*JSON*/);
+    string /*JSON*/ TestCommands(void);
+
+    PluginHost::IShell* _service;
+    Core::Sink<Notification> _notification;
+    Exchange::IMemory* _memory;
+    Exchange::ITestUtility* _testUtilityImp;
+    uint8_t _skipURL;
+    uint32_t _pid;
+};
+
+} // namespace Plugin
+} // namespace WPEFramework

--- a/TestUtility/TestUtility.h
+++ b/TestUtility/TestUtility.h
@@ -14,9 +14,13 @@ public:
     // maximum wait time for process to be spawned
     static constexpr uint32_t ImplWaitTime = 1000;
 
+public:
+    TestUtility(const TestUtility&) = delete;
+    TestUtility& operator=(const TestUtility&) = delete;
+
 private:
     class Notification : public RPC::IRemoteProcess::INotification {
-    private:
+    public:
         Notification() = delete;
         Notification(const Notification&) = delete;
 
@@ -42,7 +46,7 @@ private:
     };
 
     class Metadata : public Core::JSON::Container {
-        private:
+        public:
             Metadata(const Metadata&) = delete;
             Metadata& operator=(const Metadata&) = delete;
 
@@ -91,9 +95,6 @@ public:
     virtual Core::ProxyType<Web::Response> Process(const Web::Request& request);
 
 private:
-    TestUtility(const TestUtility&) = delete;
-    TestUtility& operator=(const TestUtility&) = delete;
-
     void Activated(RPC::IRemoteProcess* process);
     void Deactivated(RPC::IRemoteProcess* process);
 

--- a/TestUtility/TestUtilityImp.cpp
+++ b/TestUtility/TestUtilityImp.cpp
@@ -8,7 +8,7 @@ namespace TestCore {
 
     class TestUtilityImp : public Exchange::ITestUtility
     {
-        private:
+        public:
             TestUtilityImp(const TestUtilityImp&) = delete;
             TestUtilityImp& operator=(const TestUtilityImp&) = delete;
 

--- a/TestUtility/TestUtilityImp.cpp
+++ b/TestUtility/TestUtilityImp.cpp
@@ -1,0 +1,39 @@
+#include "Module.h"
+
+#include "CommandCore/TestCommandController.h"
+#include <interfaces/ITestUtility.h>
+
+namespace WPEFramework {
+namespace TestCore {
+
+    class TestUtilityImp : public Exchange::ITestUtility
+    {
+        private:
+            TestUtilityImp(const TestUtilityImp&) = delete;
+            TestUtilityImp& operator=(const TestUtilityImp&) = delete;
+
+        public:
+            TestUtilityImp(){}
+
+            virtual ~TestUtilityImp() = default;
+
+            //  ITestUtility methods
+            // -------------------------------------------------------------------------------------------------------
+            Exchange::ITestUtility::ICommand::IIterator* Commands() const override {
+                return TestCore::TestCommandController::Instance().Commands();
+            }
+
+            Exchange::ITestUtility::ICommand* Command(const string& name) const override {
+                return TestCore::TestCommandController::Instance().Command(name);
+            }
+
+            BEGIN_INTERFACE_MAP(TestUtilityImp)
+                INTERFACE_ENTRY(Exchange::ITestUtility)
+            END_INTERFACE_MAP
+
+        private:
+    };
+
+SERVICE_REGISTRATION(TestUtilityImp, 1, 0);
+} // namespace TestCore
+} // namespace WPEFramewor


### PR DESCRIPTION
TestUtility is a plugin, that allows to execute commands, to simulate
specific test conditions. This plugin can:
* Allocate a specific amount of memory
* Free previously allocated memory
* Retrieve information about currently allocated memory
* Crash plugin
* Crash plugin N times in a row

This plugin is meant to be easily extensible.