### PR TITLE
[TestController] Add TestController plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ option(PLUGIN_WEBSERVER "Include WebServer plugin" OFF)
 option(PLUGIN_WEBSHELL "Include WebShell plugin" OFF)
 option(PLUGIN_TVCONTROL "Include TVControl plugin" OFF)
 option(PLUGIN_WIFICONTROL "Include WifiControl plugin" OFF)
+option(PLUGIN_TESTCONTROLLER "Include TestController plugin" OFF)
 
 # Library installation section
 string(TOLOWER ${NAMESPACE} STORAGE_DIRECTORY)
@@ -162,4 +163,8 @@ endif()
 
 if(PLUGIN_DSGCCCLIENT)
     add_subdirectory(DsgccClient)
+endif()
+
+if(PLUGIN_TESTCONTROLLER)
+    add_subdirectory(TestController)
 endif()

--- a/TestController/CMakeLists.txt
+++ b/TestController/CMakeLists.txt
@@ -1,0 +1,30 @@
+set(PLUGIN_NAME TestController)
+set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
+
+ message("Setting up ${PLUGIN_NAME}")
+
+ find_package(${NAMESPACE}Plugins REQUIRED)
+
+ add_library(${MODULE_NAME} SHARED
+        Module.cpp
+        TestController.cpp
+        TestControllerImp.cpp
+        Core/TestAdministrator.cpp
+        Examples/Test1.cpp
+        Examples/Test2.cpp
+        Examples/Test3.cpp
+        Examples/Test4.cpp
+)
+
+ set_target_properties(${MODULE_NAME} PROPERTIES
+        CXX_STANDARD 11
+        CXX_STANDARD_REQUIRED YES)
+
+ target_link_libraries(${MODULE_NAME}
+    PRIVATE
+        ${NAMESPACE}Plugins::${NAMESPACE}Plugins)
+
+ install(TARGETS ${MODULE_NAME}
+    DESTINATION lib/${STORAGE_DIRECTORY}/plugins)
+
+ write_config(${PLUGIN_NAME})

--- a/TestController/Core/TestAdministrator.cpp
+++ b/TestController/Core/TestAdministrator.cpp
@@ -1,0 +1,58 @@
+#include "TestAdministrator.h"
+
+namespace WPEFramework {
+namespace TestCore {
+
+/* static */ TestAdministrator& TestAdministrator::Instance()
+{
+    static TestAdministrator _singleton;
+    return (_singleton);
+}
+
+void TestAdministrator::Announce(Exchange::ITestController::ICategory* category)
+{
+    ASSERT(category != nullptr);
+
+    _adminLock.Lock();
+    auto found = _testsCategories.find(category->Name());
+    ASSERT((found == _testsCategories.end()) && "Category already exists!");
+
+    if (found == _testsCategories.end())
+    {
+        _testsCategories[category->Name()] = category;
+    }
+    _adminLock.Unlock();
+
+}
+
+void TestAdministrator::Revoke(Exchange::ITestController::ICategory* category)
+{
+    ASSERT(category != nullptr);
+
+    _adminLock.Lock();
+    _testsCategories.erase(category->Name());
+    _adminLock.Unlock();
+}
+
+Exchange::ITestController::ICategory::IIterator* TestAdministrator::Categories()
+{
+    _adminLock.Lock();
+    auto iterator = Core::Service<TestCore::CategoryIterator>::Create<Exchange::ITestController::ICategory::IIterator>(_testsCategories);
+    _adminLock.Unlock();
+    return iterator;
+}
+
+Exchange::ITestController::ICategory* TestAdministrator::Category(const string& name)
+{
+    Exchange::ITestController::ICategory* result = nullptr;
+    _adminLock.Lock();
+    auto found = _testsCategories.find(name);
+    if (found != _testsCategories.end())
+    {
+        result = found->second;
+    }
+    _adminLock.Unlock();
+    return result;
+}
+} // namespace TestCore
+} // namespace WPEFramework

--- a/TestController/Core/TestAdministrator.h
+++ b/TestController/Core/TestAdministrator.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include "../Module.h"
+
+#include <interfaces/ITestController.h>
+
+namespace WPEFramework {
+namespace TestCore {
+
+using TestsContainer = std::map<string, Exchange::ITestController::ITest*>;
+using CategoriesContainer = std::map<string, Exchange::ITestController::ICategory*>;
+
+class TestIterator : public Exchange::ITestController::ITest::IIterator {
+    public:
+        TestIterator(const TestIterator&) = delete;
+        TestIterator& operator= (const TestIterator&) = delete;
+
+        using IteratorImpl = Core::IteratorMapType<TestsContainer, Exchange::ITestController::ITest*, string>;
+
+        explicit TestIterator(const TestsContainer& tests)
+            : Exchange::ITestController::ITest::IIterator()
+            , _container(tests)
+            , _iterator(_container) { }
+
+        virtual ~TestIterator() = default;
+
+        BEGIN_INTERFACE_MAP(TestIterator)
+            INTERFACE_ENTRY(Exchange::ITestController::ITest::IIterator)
+        END_INTERFACE_MAP
+
+        void Reset() override {
+            _iterator.Reset(0);
+        }
+
+        bool IsValid() const override {
+            return _iterator.IsValid();
+        }
+
+        bool Next() override {
+            return _iterator.Next();
+        }
+
+        Exchange::ITestController::ITest* Test() const override {
+            return *_iterator;
+        }
+
+        private:
+            TestsContainer _container;
+            IteratorImpl _iterator;
+};
+
+class CategoryIterator : public Exchange::ITestController::ICategory::IIterator {
+    public:
+        CategoryIterator(const CategoryIterator&) = delete;
+        CategoryIterator& operator= (const CategoryIterator&) = delete;
+
+        using IteratorImpl = Core::IteratorMapType<CategoriesContainer, Exchange::ITestController::ICategory*, string>;
+
+        explicit CategoryIterator(const CategoriesContainer& tests)
+            : Exchange::ITestController::ICategory::IIterator()
+            , _container(tests)
+            , _iterator(_container) { }
+
+        virtual ~CategoryIterator() = default;
+
+        BEGIN_INTERFACE_MAP(CategoryIterator)
+            INTERFACE_ENTRY(Exchange::ITestController::ICategory::IIterator)
+        END_INTERFACE_MAP
+
+        void Reset() override {
+            _iterator.Reset(0);
+        }
+
+        bool IsValid() const override {
+            return _iterator.IsValid();
+        }
+
+        bool Next() override {
+            return _iterator.Next();
+        }
+
+        Exchange::ITestController::ICategory* Category() const override {
+            return *_iterator;
+        }
+
+        private:
+            CategoriesContainer _container;
+            IteratorImpl _iterator;
+};
+
+class TestAdministrator {
+    private:
+        TestAdministrator()
+            : _adminLock()
+            , _testsCategories()
+        {
+        }
+
+    public:
+        TestAdministrator(const TestAdministrator&) = delete;
+        TestAdministrator& operator=(const TestAdministrator&) = delete;
+
+        static TestAdministrator& Instance();
+        ~TestAdministrator()
+        {
+            ASSERT((_testsCategories.empty() == true) && "Something went wrong");
+
+            for (auto& testCategory : _testsCategories)
+            {
+                Exchange::ITestController::ITest::IIterator* existingTests = testCategory.second->Tests();
+                while(existingTests->Next())
+                {
+                    testCategory.second->Unregister(existingTests->Test());
+                }
+                Revoke(testCategory.second);
+            }
+        }
+
+        void Announce(Exchange::ITestController::ICategory* category);
+        void Revoke(Exchange::ITestController::ICategory* category);
+
+        // TestController methods
+        Exchange::ITestController::ICategory::IIterator* Categories();
+        Exchange::ITestController::ICategory* Category(const string& name);
+
+    private:
+        mutable Core::CriticalSection _adminLock;
+        CategoriesContainer _testsCategories;
+};
+} // namespace TestCore
+} // namespace WPEFramework

--- a/TestController/Core/TestBase.h
+++ b/TestController/Core/TestBase.h
@@ -1,0 +1,59 @@
+#include "interfaces/ITestController.h"
+
+#include "../Module.h"
+#include "TestMetadata.h"
+
+namespace WPEFramework {
+
+class TestBase : public Exchange::ITestController::ITest {
+    public:
+        TestBase(const TestBase&) = delete;
+        TestBase& operator=(const TestBase&) = delete;
+
+        class DescriptionBuilder {
+            public:
+                DescriptionBuilder(const DescriptionBuilder&) = delete;
+                DescriptionBuilder& operator=(const DescriptionBuilder&) = delete;
+
+                explicit DescriptionBuilder(const string& description)
+                    : _jsonDescription()
+                {
+                    _jsonDescription.Description = description;
+                }
+
+                virtual ~DescriptionBuilder() = default;
+
+            private:
+                friend class TestBase;
+                string ToString() const
+                {
+                    string outString;
+                    _jsonDescription.ToString(outString);
+
+                    return outString;
+                }
+
+                TestCore::TestDescription _jsonDescription;
+        };
+
+        explicit TestBase(const DescriptionBuilder& description)
+            : Exchange::ITestController::ITest()
+            , _description(description.ToString())
+        { }
+
+        virtual ~TestBase() = default;
+
+        // ICommand methods
+        string Description() const final
+        {
+            return _description;
+        }
+
+        BEGIN_INTERFACE_MAP(TestBase)
+            INTERFACE_ENTRY(Exchange::ITestController::ITest)
+        END_INTERFACE_MAP
+
+    private:
+        string _description;
+};
+} // namespace WPEFramework

--- a/TestController/Core/TestCategoryBase.h
+++ b/TestController/Core/TestCategoryBase.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "../Module.h"
+
+#include <interfaces/ITestController.h>
+#include "../Core/TestAdministrator.h"
+
+namespace WPEFramework {
+namespace TestCore {
+
+class TestCategoryBase : public Exchange::ITestController::ICategory {
+    public:
+        TestCategoryBase(const TestCategoryBase&) = delete;
+        TestCategoryBase& operator=(const TestCategoryBase&) = delete;
+
+        TestCategoryBase()
+            : Exchange::ITestController::ICategory()
+            , _adminLock()
+            , _tests()
+        { }
+
+        virtual ~TestCategoryBase()
+        {
+            ASSERT((_tests.empty() == true) && "Something went wrong");
+
+            for (auto& test : _tests)
+            {
+                Unregister(test.second);
+            }
+            _tests.clear();
+        }
+
+        // ITestCategory methods
+        void Register(Exchange::ITestController::ITest* test) override
+        {
+            ASSERT(test != nullptr);
+
+            _adminLock.Lock();
+            auto found = _tests.find(test->Name());
+            ASSERT((found == _tests.end()) && "Test already exists!");
+
+            if (found == _tests.end())
+            {
+                _tests[test->Name()] = test;
+            }
+            _adminLock.Unlock();
+        }
+
+        void Unregister(Exchange::ITestController::ITest* test) override
+        {
+            ASSERT(test != nullptr);
+
+            _adminLock.Lock();
+            _tests.erase(test->Name());
+            _adminLock.Unlock();
+        }
+
+        Exchange::ITestController::ITest* Test(const string& name) const override
+        {
+            Exchange::ITestController::ITest* result = nullptr;
+            _adminLock.Lock();
+            auto found = _tests.find(name);
+            if (found != _tests.end())
+            {
+                result = found->second;
+            }
+            _adminLock.Unlock();
+            return result;
+        }
+
+        Exchange::ITestController::ITest::IIterator* Tests(void) const override
+        {
+            _adminLock.Lock();
+            auto iterator = Core::Service<TestCore::TestIterator>::Create<Exchange::ITestController::ITest::IIterator>(_tests);
+            _adminLock.Unlock();
+            return iterator;
+        }
+
+    private:
+        mutable Core::CriticalSection _adminLock;
+        TestsContainer _tests;
+};
+} // namespace TestCore
+} // namespace WPEFramework

--- a/TestController/Core/TestMetadata.h
+++ b/TestController/Core/TestMetadata.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include "../Module.h"
+
+namespace WPEFramework {
+namespace TestCore {
+
+class TestDescription : public Core::JSON::Container {
+    public:
+        TestDescription(const TestDescription&) = delete;
+        TestDescription& operator=(const TestDescription&) = delete;
+
+        TestDescription()
+            : Core::JSON::Container()
+            , Description()
+        {
+            Add(_T("description"), &Description);
+        }
+
+        ~TestDescription() = default;
+
+    public:
+        Core::JSON::String Description;
+    };
+
+class TestResult : public Core::JSON::Container {
+    public:
+        class TestStep : public Core::JSON::Container {
+            public:
+                TestStep()
+                    : Core::JSON::Container()
+                    , Description()
+                    , Status()
+                {
+                    Add(_T("testStep"), &Description);
+                    Add(_T("status"), &Status);
+                }
+
+                TestStep(const TestStep& copy)
+                    : Core::JSON::Container()
+                    , Description()
+                    , Status()
+                {
+                    this->Description = copy.Description;
+                    this->Status = copy.Status;
+
+                    Add(_T("testStep"), &Description);
+                    Add(_T("status"), &Status);
+                }
+
+                TestStep& operator=(const TestStep& rhs)
+                {
+                    this->Description = rhs.Description;
+                    this->Status = rhs.Status;
+
+                    return *this;
+                }
+
+                ~TestStep() = default;
+
+            public:
+                Core::JSON::String Description;
+                Core::JSON::String Status;
+            };
+
+    public:
+        TestResult()
+            : Core::JSON::Container()
+            , Steps()
+            , OverallStatus()
+            , Name()
+        {
+            Add(_T("test"), &Name);
+            Add(_T("status"), &OverallStatus);
+            Add(_T("steps"), &Steps);
+        }
+
+        TestResult(const TestResult& copy)
+        {
+            this->Name = copy.Name;
+            this->OverallStatus = copy.OverallStatus;
+            this->Steps = copy.Steps;
+
+            Add(_T("test"), &Name);
+            Add(_T("status"), &OverallStatus);
+            Add(_T("steps"), &Steps);
+        }
+
+        TestResult& operator=(const TestResult& rhs)
+        {
+            this->Name = rhs.Name;
+            this->OverallStatus = rhs.OverallStatus;
+            this->Steps = rhs.Steps;
+
+            return *this;
+        }
+
+        ~TestResult() = default;
+
+    public:
+        Core::JSON::ArrayType<TestStep> Steps;
+        Core::JSON::String OverallStatus;
+        Core::JSON::String Name;
+};
+} // namespace TestCore
+} // namespace WPEFramework

--- a/TestController/Core/Trace.h
+++ b/TestController/Core/Trace.h
@@ -1,0 +1,90 @@
+#pragma once
+
+namespace WPEFramework {
+namespace TestCore {
+
+class TestStart {
+    public:
+        TestStart() = delete;
+        TestStart(const TestStart& a_Copy) = delete;
+        TestStart& operator=(const TestStart& a_RHS) = delete;
+
+        TestStart(const TCHAR formatter[], ...)
+        {
+            va_list ap;
+            va_start(ap, formatter);
+            Trace::Format(_text, formatter, ap);
+            va_end(ap);
+        }
+        explicit TestStart(const string& text)
+            : _text(Core::ToString(text))
+        {
+        }
+        ~TestStart() = default;
+
+    public:
+        inline const char* Data() const { return (_text.c_str()); }
+        inline uint16_t Length() const { return (static_cast<uint16_t>(_text.length())); }
+
+    private:
+        std::string _text;
+    };
+
+class TestEnd {
+    private:
+        TestEnd() = delete;
+        TestEnd(const TestEnd& a_Copy) = delete;
+        TestEnd& operator=(const TestEnd& a_RHS) = delete;
+
+    public:
+        TestEnd(const TCHAR formatter[], ...)
+        {
+            va_list ap;
+            va_start(ap, formatter);
+            Trace::Format(_text, formatter, ap);
+            va_end(ap);
+        }
+        explicit TestEnd(const string& text)
+            : _text(Core::ToString(text))
+        {
+        }
+        ~TestEnd() = default;
+
+    public:
+        inline const char* Data() const { return (_text.c_str()); }
+        inline uint16_t Length() const { return (static_cast<uint16_t>(_text.length())); }
+
+    private:
+        std::string _text;
+};
+
+class TestStep {
+    private:
+        TestStep() = delete;
+        TestStep(const TestStep& a_Copy) = delete;
+        TestStep& operator=(const TestStep& a_RHS) = delete;
+
+    public:
+        TestStep(const TCHAR formatter[], ...)
+        {
+            va_list ap;
+            va_start(ap, formatter);
+            Trace::Format(_text, formatter, ap);
+            va_end(ap);
+        }
+        explicit TestStep(const string& text)
+            : _text(Core::ToString(text))
+        {
+        }
+        ~TestStep() = default;
+
+    public:
+        inline const char* Data() const { return (_text.c_str()); }
+        inline uint16_t Length() const { return (static_cast<uint16_t>(_text.length())); }
+
+    private:
+        std::string _text;
+};
+
+} // namespace TestCore
+} // namespace WPEFramework

--- a/TestController/Examples/Test1.cpp
+++ b/TestController/Examples/Test1.cpp
@@ -1,0 +1,53 @@
+#include "../Module.h"
+
+#include "../Core/TestBase.h"
+#include "../Core/Trace.h"
+#include <interfaces/ITestController.h>
+#include "TestCategory1.h"
+
+namespace WPEFramework {
+
+class Test1 : public TestBase {
+    public:
+        Test1(const Test1&) = delete;
+        Test1& operator=(const Test1&) = delete;
+
+        Test1()
+            : TestBase(TestBase::DescriptionBuilder("Test 1 description"))
+        {
+            TestCore::TestCategory1::Instance().Register(this);
+        }
+
+        virtual ~Test1()
+        {
+            TestCore::TestCategory1::Instance().Unregister(this);
+        }
+
+    public:
+        // ICommand methods
+        string Execute(const string& params) final
+        {
+            TestCore::TestResult jsonResult;
+            string result;
+            TRACE(TestCore::TestStart, (_T("Start execute of test: %s"), _name.c_str()));
+
+            TRACE(TestCore::TestStep, (_T("Do real test execution"), _name.c_str()));
+            jsonResult.Name = _name;
+            jsonResult.OverallStatus = "Success";
+
+            TRACE(TestCore::TestStart, (_T("End test: %s"), _name.c_str()));
+            jsonResult.ToString(result);
+            return result;
+        }
+
+        string Name() const final
+        {
+            return _name;
+        }
+
+    private:
+        const string _name = _T("Test1");
+};
+
+static Exchange::ITestController::ITest* _singleton(Core::Service<Test1>::Create<Exchange::ITestController::ITest>());
+} // namespace WPEFramework

--- a/TestController/Examples/Test2.cpp
+++ b/TestController/Examples/Test2.cpp
@@ -1,0 +1,53 @@
+#include "../Module.h"
+
+#include "../Core/TestBase.h"
+#include "../Core/Trace.h"
+#include <interfaces/ITestController.h>
+#include "TestCategory1.h"
+
+namespace WPEFramework {
+
+class Test2 : public TestBase {
+    public:
+        Test2(const Test2&) = delete;
+        Test2& operator=(const Test2&) = delete;
+
+        Test2()
+            : TestBase(TestBase::DescriptionBuilder("Test 2 description"))
+        {
+            TestCore::TestCategory1::Instance().Register(this);
+        }
+
+        virtual ~Test2()
+        {
+            TestCore::TestCategory1::Instance().Unregister(this);
+        }
+
+    public:
+        // ICommand methods
+        string Execute(const string& params) final
+        {
+            TestCore::TestResult jsonResult;
+            string result;
+            TRACE(TestCore::TestStart, (_T("Start execute of test: %s"), _name.c_str()));
+
+            TRACE(TestCore::TestStep, (_T("Do real test execution"), _name.c_str()));
+            jsonResult.Name = _name;
+            jsonResult.OverallStatus = "Success";
+
+            TRACE(TestCore::TestStart, (_T("End test: %s"), _name.c_str()));
+            jsonResult.ToString(result);
+            return result;
+        }
+
+        string Name() const final
+        {
+            return _name;
+        }
+
+    private:
+        const string _name = _T("Test2");
+};
+
+static Exchange::ITestController::ITest* _singleton(Core::Service<Test2>::Create<Exchange::ITestController::ITest>());
+} // namespace WPEFramework

--- a/TestController/Examples/Test3.cpp
+++ b/TestController/Examples/Test3.cpp
@@ -1,0 +1,53 @@
+#include "../Module.h"
+
+#include "../Core/TestBase.h"
+#include "../Core/Trace.h"
+#include <interfaces/ITestController.h>
+#include "TestCategory2.h"
+
+namespace WPEFramework {
+
+class Test3 : public TestBase {
+    public:
+        Test3(const Test3&) = delete;
+        Test3& operator=(const Test3&) = delete;
+
+        Test3()
+            : TestBase(TestBase::DescriptionBuilder("Test 3 description"))
+        {
+            TestCore::TestCategory2::Instance().Register(this);
+        }
+
+        virtual ~Test3()
+        {
+            TestCore::TestCategory2::Instance().Unregister(this);
+        }
+
+    public:
+        // ICommand methods
+        string Execute(const string& params) final
+        {
+            TestCore::TestResult jsonResult;
+            string result;
+            TRACE(TestCore::TestStart, (_T("Start execute of test: %s"), _name.c_str()));
+
+            TRACE(TestCore::TestStep, (_T("Do real test execution"), _name.c_str()));
+            jsonResult.Name = _name;
+            jsonResult.OverallStatus = "Success";
+
+            TRACE(TestCore::TestStart, (_T("End test: %s"), _name.c_str()));
+            jsonResult.ToString(result);
+            return result;
+        }
+
+        string Name() const final
+        {
+            return _name;
+        }
+
+    private:
+        const string _name = _T("Test3");
+};
+
+static Exchange::ITestController::ITest* _singleton(Core::Service<Test3>::Create<Exchange::ITestController::ITest>());
+} // namespace WPEFramework

--- a/TestController/Examples/Test4.cpp
+++ b/TestController/Examples/Test4.cpp
@@ -1,0 +1,53 @@
+#include "../Module.h"
+
+#include "../Core/TestBase.h"
+#include "../Core/Trace.h"
+#include <interfaces/ITestController.h>
+#include "TestCategory2.h"
+
+namespace WPEFramework {
+
+class Test4 : public TestBase {
+    public:
+        Test4(const Test4&) = delete;
+        Test4& operator=(const Test4&) = delete;
+
+        Test4()
+            : TestBase(TestBase::DescriptionBuilder("Test 4 description"))
+        {
+            TestCore::TestCategory2::Instance().Register(this);;
+        }
+
+        virtual ~Test4()
+        {
+            TestCore::TestCategory2::Instance().Unregister(this);
+        }
+
+    public:
+        // ICommand methods
+        string Execute(const string& params) final
+        {
+            TestCore::TestResult jsonResult;
+            string result;
+            TRACE(TestCore::TestStart, (_T("Start execute of test: %s"), _name.c_str()));
+
+            TRACE(TestCore::TestStep, (_T("Do real test execution"), _name.c_str()));
+            jsonResult.Name = _name;
+            jsonResult.OverallStatus = "Success";
+
+            TRACE(TestCore::TestStart, (_T("End test: %s"), _name.c_str()));
+            jsonResult.ToString(result);
+            return result;
+        }
+
+        string Name() const final
+        {
+            return _name;
+        }
+
+    private:
+        const string _name = _T("Test4");
+};
+
+static Exchange::ITestController::ITest* _singleton(Core::Service<Test4>::Create<Exchange::ITestController::ITest>());
+} // namespace WPEFramework

--- a/TestController/Examples/TestCategory1.h
+++ b/TestController/Examples/TestCategory1.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "../Module.h"
+
+#include <interfaces/ITestController.h>
+#include "../Core/TestAdministrator.h"
+#include "../Core/TestCategoryBase.h"
+
+namespace WPEFramework {
+namespace TestCore {
+
+class TestCategory1 : TestCore::TestCategoryBase {
+    protected:
+        TestCategory1()
+            : TestCategoryBase()
+        {
+            TestCore::TestAdministrator::Instance().Announce(this);
+        }
+    public:
+        TestCategory1(const TestCategory1&) = delete;
+        TestCategory1& operator=(const TestCategory1&) = delete;
+        virtual ~TestCategory1() = default;
+
+        static Exchange::ITestController::ICategory& Instance()
+        {
+            static Exchange::ITestController::ICategory* _singleton(Core::Service<TestCategory1>::Create<Exchange::ITestController::ICategory>());
+            return (*_singleton);
+        }
+
+        // ITestCategory methods
+        string Name() const override
+        {
+            return _name;
+        };
+
+        void Setup() override
+        {
+            /*ToDo: Implement Setup for selected category */
+        };
+
+        void TearDown() override
+        {
+            /*ToDo: Implement TearDown for selected category */
+        };
+
+        BEGIN_INTERFACE_MAP(TestCategory1)
+            INTERFACE_ENTRY(Exchange::ITestController::ICategory)
+        END_INTERFACE_MAP
+
+    private:
+        const string _name = _T("TestCategory1");
+};
+} // namespace TestCore
+} // namespace WPEFramework

--- a/TestController/Examples/TestCategory2.h
+++ b/TestController/Examples/TestCategory2.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "../Module.h"
+
+#include <interfaces/ITestController.h>
+#include "../Core/TestAdministrator.h"
+#include "../Core/TestCategoryBase.h"
+
+namespace WPEFramework {
+namespace TestCore {
+
+class TestCategory2 : TestCore::TestCategoryBase {
+    protected:
+        TestCategory2()
+            : TestCategoryBase()
+        {
+            TestCore::TestAdministrator::Instance().Announce(this);
+        }
+    public:
+        TestCategory2(const TestCategory2&) = delete;
+        TestCategory2& operator=(const TestCategory2&) = delete;
+        virtual ~TestCategory2() = default;
+
+        static Exchange::ITestController::ICategory& Instance()
+        {
+            static Exchange::ITestController::ICategory* _singleton(Core::Service<TestCategory2>::Create<Exchange::ITestController::ICategory>());
+            return (*_singleton);
+        }
+
+        // ITestCategory methods
+        string Name() const override
+        {
+            return _name;
+        };
+
+        void Setup() override
+        {
+            /*ToDo: Implement Setup for selected category */
+        };
+
+        void TearDown() override
+        {
+            /*ToDo: Implement TearDown for selected category */
+        };
+
+        BEGIN_INTERFACE_MAP(TestCategory2)
+            INTERFACE_ENTRY(Exchange::ITestController::ICategory)
+        END_INTERFACE_MAP
+
+    private:
+        const string _name = _T("TestCategory2");
+};
+} // namespace TestCore
+} // namespace WPEFramework

--- a/TestController/Module.cpp
+++ b/TestController/Module.cpp
@@ -1,0 +1,3 @@
+#include "Module.h"
+
+MODULE_NAME_DECLARATION(BUILD_REFERENCE)

--- a/TestController/Module.h
+++ b/TestController/Module.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#ifndef MODULE_NAME
+#define MODULE_NAME Plugin_TestController
+#endif
+
+#include <plugins/plugins.h>
+
+#undef EXTERNAL
+#define EXTERNAL

--- a/TestController/TestController.config
+++ b/TestController/TestController.config
@@ -1,0 +1,9 @@
+set (autostart true)
+
+map()
+    key(root)
+    map()
+      kv(outofprocess true)
+    end()
+end()
+ans(configuration)

--- a/TestController/TestController.cpp
+++ b/TestController/TestController.cpp
@@ -1,0 +1,451 @@
+#include "TestController.h"
+
+namespace WPEFramework {
+namespace TestController {
+
+Exchange::IMemory* MemoryObserver(const uint32_t pid)
+{
+    class MemoryObserverImpl : public Exchange::IMemory {
+    public:
+        MemoryObserverImpl() = delete;
+        MemoryObserverImpl(const MemoryObserverImpl&) = delete;
+        MemoryObserverImpl& operator=(const MemoryObserverImpl&) = delete;
+
+        MemoryObserverImpl(const uint32_t id)
+            : _main(id == 0 ? Core::ProcessInfo().Id() : id)
+            , _observable(false)
+        {
+        }
+        ~MemoryObserverImpl() {}
+
+    public:
+        virtual void Observe(const uint32_t pid)
+        {
+            if (pid == 0)
+            {
+                _observable = false;
+            }
+            else
+            {
+                _observable = true;
+                _main = Core::ProcessInfo(pid);
+            }
+        }
+        virtual uint64_t Resident() const { return (_observable == false ? 0 : _main.Resident()); }
+
+        virtual uint64_t Allocated() const { return (_observable == false ? 0 : _main.Allocated()); }
+
+        virtual uint64_t Shared() const { return (_observable == false ? 0 : _main.Shared()); }
+
+        virtual uint8_t Processes() const { return (IsOperational() ? 1 : 0); }
+
+        virtual const bool IsOperational() const { return (_observable == false) || (_main.IsActive()); }
+
+        BEGIN_INTERFACE_MAP(MemoryObserverImpl)
+        INTERFACE_ENTRY(Exchange::IMemory)
+        END_INTERFACE_MAP
+
+    private:
+        Core::ProcessInfo _main;
+        bool _observable;
+    };
+
+    return (Core::Service<MemoryObserverImpl>::Create<Exchange::IMemory>(pid));
+}
+} // namespace TestController
+
+namespace Plugin {
+SERVICE_REGISTRATION(TestController, 1, 0);
+
+/* virtual */ const string TestController::Initialize(PluginHost::IShell* service)
+{
+    /*Assume that everything is OK*/
+    string message = EMPTY_STRING;
+    Config config;
+
+    ASSERT(service != nullptr);
+    ASSERT(_service == nullptr);
+    ASSERT(_testControllerImp == nullptr);
+    ASSERT(_memory == nullptr);
+
+    _service = service;
+    _skipURL = static_cast<uint8_t>(_service->WebPrefix().length());
+    _service->Register(&_notification);
+    _testControllerImp = _service->Root<Exchange::ITestController>(_pid, ImplWaitTime, _T("TestControllerImp"));
+
+    if ((_testControllerImp != nullptr) && (_service != nullptr))
+    {
+        _memory = WPEFramework::TestController::MemoryObserver(_pid);
+        ASSERT(_memory != nullptr);
+        _memory->Observe(_pid);
+        _testControllerImp->Setup();
+    }
+    else
+    {
+        ProcessTermination(_pid);
+        _service = nullptr;
+        _testControllerImp = nullptr;
+        _service->Unregister(&_notification);
+
+        TRACE(Trace::Fatal, (_T("*** TestController could not be instantiated ***")))
+        message = _T("TestUtility could not be instantiated.");
+    }
+
+    return message;
+}
+
+/* virtual */ void TestController::Deinitialize(PluginHost::IShell* service)
+{
+    ASSERT(_service == service);
+    ASSERT(_testControllerImp != nullptr);
+    ASSERT(_memory != nullptr);
+
+    _testControllerImp->TearDown();
+
+    if (_testControllerImp->Release() != Core::ERROR_DESTRUCTION_SUCCEEDED)
+    {
+        TRACE_L1("TestController Plugin is not properly destructed. %d", _pid);
+        ProcessTermination(_pid);
+    }
+
+    _testControllerImp = nullptr;
+    _memory->Release();
+    _memory = nullptr;
+    _service->Unregister(&_notification);
+    _service = nullptr;
+}
+
+/* virtual */ string TestController::Information() const
+{
+    // No additional info to report.
+    return ((_T("The purpose of this plugin is provide ability to execute functional tests.")));
+}
+
+static Core::ProxyPoolType<Web::TextBody> _testControllerMetadata(2);
+
+/* virtual */ void TestController::Inbound(Web::Request& request)
+{
+    if (request.Verb == Web::Request::HTTP_POST)
+    {
+        request.Body(_testControllerMetadata.Element());
+    }
+}
+
+/* virtual */ Core::ProxyType<Web::Response> TestController::Process(const Web::Request& request)
+{
+    ASSERT(_skipURL <= request.Path.length());
+    Core::ProxyType<Web::Response> result(PluginHost::Factories::Instance().Response());
+
+    if (_testControllerImp != nullptr)
+    {
+        Core::ProxyType<Web::TextBody> body(_testControllerMetadata.Element());
+        string requestBody = EMPTY_STRING;
+
+        if ((request.Verb == Web::Request::HTTP_POST) && (request.HasBody()))
+        {
+            requestBody = (*request.Body<Web::TextBody>());
+        }
+
+        (*body) = HandleRequest(request.Verb, request.Path, _skipURL, requestBody);
+        if((*body) != EMPTY_STRING)
+        {
+            result->Body<Web::TextBody>(body);
+            result->ErrorCode = Web::STATUS_OK;
+            result->Message = (_T("OK"));
+            result->ContentType = Web::MIMETypes::MIME_JSON;
+        }
+        else
+        {
+            result->ErrorCode = Web::STATUS_BAD_REQUEST;
+            result->Message = (_T("Method is not supported"));
+        }
+    }
+    else
+    {
+        result->ErrorCode = Web::STATUS_METHOD_NOT_ALLOWED;
+        result->Message = (_T("Test controller does not exist"));
+    }
+    return result;
+}
+
+void TestController::ProcessTermination(uint32_t pid)
+{
+    RPC::IRemoteProcess* process(_service->RemoteProcess(pid));
+    if (process != nullptr)
+    {
+        process->Terminate();
+        process->Release();
+    }
+}
+
+void TestController::Activated(RPC::IRemoteProcess* /*process*/)
+{
+    return;
+}
+
+void TestController::Deactivated(RPC::IRemoteProcess* process)
+{
+    if (_pid == process->Id())
+    {
+        ASSERT(_service != nullptr);
+        PluginHost::WorkerPool::Instance().Submit(PluginHost::IShell::Job::Create(_service, PluginHost::IShell::DEACTIVATED, PluginHost::IShell::FAILURE));
+    }
+}
+
+string /*JSON*/ TestController::TestCategories(Exchange::ITestController::ICategory::IIterator* categories)
+{
+    string response = EMPTY_STRING;
+    MetadataCategory testCategories;
+
+    ASSERT(categories != nullptr);
+
+    if (categories != nullptr)
+    {
+        while (categories->Next())
+        {
+            Core::JSON::String name;
+            name = categories->Category()->Name();
+            testCategories.TestCategories.Add(name);
+        }
+        testCategories.ToString(response);
+    }
+    return response;
+}
+
+string /*JSON*/ TestController::Tests(Exchange::ITestController::ITest::IIterator* tests)
+{
+    string response = EMPTY_STRING;
+    MetadataTest testsItems;
+
+    ASSERT(tests != nullptr);
+
+    if (tests != nullptr)
+    {
+        while (tests->Next())
+        {
+            Core::JSON::String name;
+            name = tests->Test()->Name();
+            testsItems.Tests.Add(name);
+        }
+        testsItems.ToString(response);
+    }
+
+    return response;
+}
+
+string /*JSON*/ TestController::RunAll(const string& body, const string& categoryName)
+{
+    string result = EMPTY_STRING;
+    OverallTestResults jsonResults;
+
+    if (categoryName == EMPTY_STRING)
+    {
+        Exchange::ITestController::ICategory::IIterator* categories = _testControllerImp->Categories();
+        ASSERT(categories != nullptr);
+
+        if (categories != nullptr)
+        {
+            while (categories->Next())
+            {
+                TestPreparation(categories->Category(), categories->Category()->Name());
+
+                auto tests = categories->Category()->Tests();
+                while (tests->Next())
+                {
+                    result = tests->Test()->Execute(body);
+
+                    TestCore::TestResult ret;
+                    if (ret.FromString(result))
+                    {
+                        jsonResults.Results.Add(ret);
+                    }
+                }
+            }
+        }
+    }
+    else
+    {
+        Exchange::ITestController::ICategory* category = _testControllerImp->Category(categoryName);
+        ASSERT(category != nullptr);
+
+        if (category != nullptr)
+        {
+            TestPreparation(category, categoryName);
+
+            auto tests = category->Tests();
+            while (tests->Next())
+            {
+                result = tests->Test()->Execute(body);
+
+                TestCore::TestResult ret;
+                if (ret.FromString(result))
+                {
+                    jsonResults.Results.Add(ret);
+                }
+            }
+        }
+    }
+
+    result = EMPTY_STRING;
+    jsonResults.ToString(result);
+    return result;
+}
+
+string /*JSON*/ TestController::RunTest(const string& body, const string& categoryName, const string& testName)
+{
+    string response = EMPTY_STRING;
+
+    Exchange::ITestController::ICategory* category = _testControllerImp->Category(categoryName);
+    ASSERT(category != nullptr);
+
+    if (category != nullptr)
+    {
+        TestPreparation(category, categoryName);
+
+        auto test = category->Test(testName);
+
+        if (test != nullptr)
+        {
+            response = test->Execute(body);
+        }
+    }
+
+    return response;
+}
+
+void TestController::TestPreparation(Exchange::ITestController::ICategory* const category, const string& categoryName)
+{
+    if (_prevCategory != categoryName)
+    {
+        if (_prevCategory != EMPTY_STRING)
+        {
+            Exchange::ITestController::ICategory* prevCategory = _testControllerImp->Category(_prevCategory);
+            if (prevCategory != nullptr)
+                prevCategory->TearDown();
+        }
+        category->Setup();
+        _prevCategory = categoryName;
+    }
+}
+
+string /*JSON*/ TestController::HandleRequest(Web::Request::type type, const string& path, const uint8_t skipUrl, const string& body /*JSON*/)
+{
+    bool executed = false;
+    // Return empty result in case of issue
+    string /*JSON*/ response = EMPTY_STRING;
+
+    Core::TextSegmentIterator index(Core::TextFragment(path, skipUrl, path.length() - skipUrl), false, '/');
+
+    index.Next();
+    index.Next();
+    // Here process request other than:
+    // GET /Service/<CALLSIGN>/TestCategories
+    // GET /Service/<CALLSIGN>/<TEST_CATEGORY>/Tests
+    // GET /Service/<CALLSIGN>/<TEST_CATEGORY>/<TEST_NAME>/Description
+    // POST/PUT /Service/<CALLSIGN>/TestCategories/Run
+    // POST/PUT /Service/<CALLSIGN>/<TEST_CATEGORY>/Run
+    // POST/PUT /Service/<CALLSIGN>/<TEST_CATEGORY>/<TEST_NAME>
+
+    if (index.Current().Text() == _T("TestCategories"))
+    {
+        if (type == Web::Request::HTTP_GET)
+        {
+            if (!index.Next())
+            {
+                auto categories = _testControllerImp->Categories();
+                ASSERT(categories != nullptr);
+
+                // Get list of Category
+                response = TestCategories(categories);
+                executed = true;
+            }
+        }
+        else if ((type == Web::Request::HTTP_POST) || (type == Web::Request::HTTP_PUT))
+        {
+            index.Next();
+            if (index.Current().Text() == _T("Run"))
+            {
+                if(!index.Next())
+                {
+                    response = RunAll(body);
+                    executed = true;
+                }
+            }
+        }
+    }
+    else
+    {
+        string testCategory = index.Current().Text();
+
+        auto category = _testControllerImp->Category(testCategory);
+
+        if (category != nullptr)
+        {
+            index.Next();
+            if (type == Web::Request::HTTP_GET)
+            {
+                if (index.Current().Text() == _T("Tests"))
+                {
+                    if (!index.Next())
+                    {
+                        // Get Tests list per Category
+                        response = Tests(category->Tests());
+                        executed = true;
+                    }
+                }
+                else
+                {
+                    auto test = category->Test(index.Current().Text());
+
+                    if (test != nullptr)
+                    {
+                        if (index.Current().Text() == test->Name())
+                        {
+                            if (index.Next())
+                            {
+                                if (index.Current().Text() == _T("Description"))
+                                {
+                                    if(!index.Next())
+                                    {
+                                        response = test->Description();
+                                        executed = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            else if ((type == Web::Request::HTTP_POST) || (type == Web::Request::HTTP_PUT))
+            {
+                string request = index.Current().Text();
+                if (request == _T("Run"))
+                {
+                    if (!index.Next())
+                    {
+                        response = RunAll(body, category->Name());
+                        executed = true;
+                    }
+                }
+                else
+                {
+                    if (!index.Next())
+                    {
+                        //Process particular test requests if it is valid
+                        response = RunTest(body, category->Name(), request);
+                        executed = true;
+                    }
+                }
+            }
+        }
+    }
+
+    if (!executed)
+    {
+        TRACE(Trace::Fatal, (_T("*** Wrong request !!! ***")))
+    }
+
+    return response;
+}
+} // namespace Plugin
+} // namespace WPEFramework

--- a/TestController/TestController.h
+++ b/TestController/TestController.h
@@ -1,0 +1,155 @@
+#pragma once
+
+#include "Module.h"
+
+#include <interfaces/IMemory.h>
+#include <interfaces/ITestController.h>
+
+#include "Core/TestMetadata.h"
+
+namespace WPEFramework {
+namespace Plugin {
+
+class TestController : public PluginHost::IPlugin, public PluginHost::IWeb {
+public:
+    // maximum wait time for process to be spawned
+    static constexpr uint32_t ImplWaitTime = 1000;
+
+private:
+    class Notification : public RPC::IRemoteProcess::INotification {
+    public:
+        Notification() = delete;
+        Notification(const Notification&) = delete;
+
+        explicit Notification(TestController* parent)
+            : _parent(*parent)
+        {
+            ASSERT(parent != nullptr);
+        }
+        virtual ~Notification() {}
+
+    public:
+        virtual void Activated(RPC::IRemoteProcess* process) { _parent.Activated(process); }
+
+        virtual void Deactivated(RPC::IRemoteProcess* process) { _parent.Deactivated(process); }
+
+        BEGIN_INTERFACE_MAP(Notification)
+        INTERFACE_ENTRY(RPC::IRemoteProcess::INotification)
+        END_INTERFACE_MAP
+
+    private:
+        TestController& _parent;
+    };
+
+    class MetadataCategory : public Core::JSON::Container {
+        public:
+            MetadataCategory(const MetadataCategory&) = delete;
+            MetadataCategory& operator=(const MetadataCategory&) = delete;
+
+            MetadataCategory()
+                : Core::JSON::Container()
+                , TestCategories()
+            {
+                Add(_T("testCategories"), &TestCategories);
+            }
+            ~MetadataCategory() {}
+
+        public:
+            Core::JSON::ArrayType<Core::JSON::String> TestCategories;
+    };
+
+    class MetadataTest : public Core::JSON::Container {
+        public:
+            MetadataTest(const MetadataTest&) = delete;
+            MetadataTest& operator=(const MetadataTest&) = delete;
+
+            MetadataTest()
+                : Core::JSON::Container()
+                , Tests()
+            {
+                Add(_T("tests"), &Tests);
+            }
+            ~MetadataTest() {}
+
+        public:
+            Core::JSON::ArrayType<Core::JSON::String> Tests;
+    };
+
+    class OverallTestResults : public Core::JSON::Container {
+        private:
+            OverallTestResults(const OverallTestResults&) = delete;
+            OverallTestResults& operator=(const OverallTestResults&) = delete;
+
+        public:
+            OverallTestResults()
+                : Core::JSON::Container()
+                , Results()
+            {
+                Add(_T("testsResults"), &Results);
+            }
+
+            ~OverallTestResults() = default;
+
+        public:
+            Core::JSON::ArrayType<TestCore::TestResult> Results;
+    };
+
+public:
+    TestController()
+        : _service(nullptr)
+        , _notification(this)
+        , _memory(nullptr)
+        , _testControllerImp(nullptr)
+        , _skipURL(0)
+        , _pid(0)
+        , _prevCategory(EMPTY_STRING)
+    {
+    }
+
+    virtual ~TestController() {}
+
+    BEGIN_INTERFACE_MAP(TestController)
+        INTERFACE_ENTRY(PluginHost::IPlugin)
+        INTERFACE_ENTRY(PluginHost::IWeb)
+        INTERFACE_AGGREGATE(Exchange::IMemory, _memory)
+        INTERFACE_AGGREGATE(Exchange::ITestController, _testControllerImp)
+    END_INTERFACE_MAP
+
+    //   IPlugin methods
+    // -------------------------------------------------------------------------------------------------------
+    virtual const string Initialize(PluginHost::IShell* service) override;
+    virtual void Deinitialize(PluginHost::IShell* service) override;
+    virtual string Information() const override;
+
+    //  IWeb methods
+    // -------------------------------------------------------------------------------------------------------
+    virtual void Inbound(Web::Request& request);
+    virtual Core::ProxyType<Web::Response> Process(const Web::Request& request);
+
+    TestController(const TestController&) = delete;
+    TestController& operator=(const TestController&) = delete;
+private:
+
+    void Activated(RPC::IRemoteProcess* process);
+    void Deactivated(RPC::IRemoteProcess* process);
+
+    void ProcessTermination(uint32_t pid);
+
+    void TestPreparation(Exchange::ITestController::ICategory* const category, const string& categoryName);
+    string /*JSON*/ HandleRequest(Web::Request::type type, const string& path, const uint8_t skipUrl, const string& body /*JSON*/);
+    string /*JSON*/ TestCategories(Exchange::ITestController::ICategory::IIterator* categories);
+    string /*JSON*/ Tests(Exchange::ITestController::ITest::IIterator* tests);
+    string /*JSON*/ RunAll(const string& body, const string& categoryName = EMPTY_STRING);
+    string /*JSON*/ RunTest(const string& body, const string& categoryName, const string& testName);
+
+    PluginHost::IShell* _service;
+    Core::Sink<Notification> _notification;
+    Exchange::IMemory* _memory;
+    Exchange::ITestController* _testControllerImp;
+    uint8_t _skipURL;
+    uint32_t _pid;
+    string _prevCategory;
+};
+
+} // namespace Plugin
+} // namespace WPEFramework

--- a/TestController/TestControllerImp.cpp
+++ b/TestController/TestControllerImp.cpp
@@ -1,0 +1,50 @@
+#include "Module.h"
+
+#include <interfaces/ITestController.h>
+
+#include "Core/TestAdministrator.h"
+
+namespace WPEFramework {
+namespace TestCore {
+
+    class TestControllerImp : public Exchange::ITestController
+    {
+        public:
+            TestControllerImp() = default;
+            TestControllerImp(const TestControllerImp&) = delete;
+            TestControllerImp& operator=(const TestControllerImp&) = delete;
+
+            virtual ~TestControllerImp() {}
+
+            //  TestControllerImp methods
+            // -------------------------------------------------------------------------------------------------------
+            virtual void Setup()
+            {
+                //This is overall TestController setup
+                //ToDo: Do 'Setup' for ITestController if it is needed
+            };
+            virtual void TearDown()
+            {
+                //This is overall TestController tear down
+                //ToDo: Do 'Tear Down' for ITestController if it is needed
+            };
+
+            virtual ICategory::IIterator* Categories() const override
+            {
+                return TestCore::TestAdministrator::Instance().Categories();
+            }
+
+            virtual ICategory* Category(const string& category) const override
+            {
+                return TestCore::TestAdministrator::Instance().Category(category);
+            }
+
+            BEGIN_INTERFACE_MAP(TestControllerImp)
+                INTERFACE_ENTRY(Exchange::ITestController)
+            END_INTERFACE_MAP
+        private:
+    };
+
+SERVICE_REGISTRATION(TestControllerImp, 1, 0);
+} // namespace TestCore
+} // namespace WPEFramewor


### PR DESCRIPTION
TestController is a plugin, that allows to execute standalone tests.
Following REST API is exposed:
// GET /Service/<CALLSIGN>/TestCategories
// GET /Service/<CALLSIGN>/<TEST_CATEGORY>/Tests
// GET /Service/<CALLSIGN>/<TEST_CATEGORY>/<TEST_NAME>/Description
// POST/PUT /Service/<CALLSIGN>/TestCategories/Run
// POST/PUT /Service/<CALLSIGN>/<TEST_CATEGORY>/Run
// POST/PUT /Service/<CALLSIGN>/<TEST_CATEGORY>/<TEST_NAME>