### PR TITLE
[Monitor] Fix operational setting. Only use it to control restart all…

### DIFF
--- a/Monitor/Monitor.h
+++ b/Monitor/Monitor.h
@@ -618,7 +618,7 @@ namespace Plugin {
                         if ((_operationalInterval != 0) && (_operationalSlots == 0)) {
                             bool operational = _source->IsOperational();
                             _measurement.Operational(operational);
-                            if ((operational == false) && (_operationalEvaluate == true)) {
+                            if (operational == false) {
                                 status |= NOT_OPERATIONAL;
                                 TRACE_L1("Status not operational. %d", __LINE__);
                             }


### PR DESCRIPTION
…owed and always measure. If you don't measure, you can't restart.

With the previous implementation if you disabled operational in the settings (e.g. operational -1) the evaluate never measured the operational status. Thus never triggering the notification. 

In this change the Monitor notification is still sent letting everyone know the process died, however restarting is toggled by the HasRestartAllowed() which is controlled by setting operational to >= 0 or -1 to disable.