### PR TITLE
Correct printf() arguments

### DIFF
--- a/tests/JSONRPCClient/JSONRPCClient.cpp
+++ b/tests/JSONRPCClient/JSONRPCClient.cpp
@@ -205,7 +205,7 @@ int main(int argc, char** argv)
                 // 4. [mandatory] Response to be received from the other side.
                 Data::Response response;
                 remoteObject.Invoke<Data::Parameters, Data::Response>(1000, _T("extended"), Data::Parameters(_T("JustSomeText"), true), response);
-                printf("received time: %llu - %d\n", response.Time.Value(), response.State.Value());
+                printf("received time: %ju - %d\n", (intmax_t)response.Time.Value(), response.State.Value());
                 break;
             }
             case 'R': {


### PR DESCRIPTION
Fixes:
WPEFrameworkPlugins/tests/JSONRPCClient/JSONRPCClient.cpp:208:24: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 2 has type ‘long unsigned int’ [-Wformat=]
                 printf("received time: %llu - %d\n", response.Time.Value(), response.State.Value());
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~~~~~~~~~~~