### PR TITLE
2.22 compilation fixes rebased on top of plugins' HEAD

### DIFF
--- a/WebKitBrowser/CMakeLists.txt
+++ b/WebKitBrowser/CMakeLists.txt
@@ -31,6 +31,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(${NAMESPACE}Plugins REQUIRED)
 find_package(GLIB REQUIRED)
 find_package(WPEWebKit REQUIRED)
+find_package(WPEBackend REQUIRED)
 
 add_library(${MODULE_NAME} SHARED  
     Module.cpp
@@ -48,11 +49,13 @@ set_target_properties(${MODULE_NAME} PROPERTIES
 target_link_libraries(${MODULE_NAME}
     PRIVATE 
         ${NAMESPACE}Plugins::${NAMESPACE}Plugins
+        ${WPE_BACKEND_LIBRARIES}
         ${GLIB_LIBRARIES}
         ${WPE_WEBKIT_LIBRARIES})
 
 target_include_directories(${MODULE_NAME} 
     PRIVATE 
+        ${WPE_BACKEND_INCLUDE_DIRS}
         ${WPE_WEBKIT_INCLUDE_DIRS}
         ${WPE_WEBKIT_INCLUDE_DIRS}/WPE
         ${GLIB_INCLUDE_DIRS})

--- a/WebKitBrowser/WebKitImplementation.cpp
+++ b/WebKitBrowser/WebKitImplementation.cpp
@@ -13,6 +13,7 @@
 #include <WPE/WebKit/WKNotificationProvider.h>
 #include <WPE/WebKit/WKSoupSession.h>
 #include <WPE/WebKit/WKUserMediaPermissionRequest.h>
+#include <wpe/wpe.h>
 
 #include <glib.h>
 
@@ -1036,7 +1037,7 @@ static GSourceFuncs _handlerIntervention =
             auto cookieManager = WKContextGetCookieManager(context);
             WKCookieManagerSetCookiePersistentStorage(cookieManager, path, kWKCookieStorageTypeSQLite);
 
-            _view = WKViewCreate(pageConfiguration);
+            _view = WKViewCreate(wpe_view_backend_create(), pageConfiguration);
             if (_config.FPS.Value() == true) {
                 _viewClient.base.clientInfo = static_cast<void*>(this);
                 WKViewSetViewClient(_view, &_viewClient.base);

--- a/cmake/FindWPEBackend.cmake
+++ b/cmake/FindWPEBackend.cmake
@@ -1,0 +1,46 @@
+# - Try to find WpeBackend
+# Once done this will define
+#  WPE_BACKEND_FOUND - System has libwpe
+#  WPE_BACKEND_INCLUDE_DIRS - The libwpe include directories
+#  WPE_BACKEND_LIBRARIES - The libraries needed to use libwpe
+#
+# Copyright (C) 2019 Metrological.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+find_package(PkgConfig)
+pkg_check_modules(PC_WPE_BACKEND QUIET wpe-0.2)
+
+find_path(WPE_BACKEND_INCLUDE_DIRS
+    NAMES wpe/wpe.h
+    HINTS ${PC_WPE_BACKEND_INCLUDEDIR} ${PC_WPE_BACKEND_INCLUDE_DIRS}
+)
+
+find_library(WPE_BACKEND_LIBRARIES
+    NAMES wpe-0.2
+    HINTS ${PC_WPE_BACKEND_LIBDIR} ${PC_WPE_BACKEND_LIBRARY_DIRS}
+)
+
+mark_as_advanced(WPE_BACKEND_INCLUDE_DIRS WPE_BACKEND_LIBRARIES)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(WPEBACKEND REQUIRED_VARS WPE_BACKEND_INCLUDE_DIRS WPE_BACKEND_LIBRARIES)

--- a/cmake/FindWPEWebKit.cmake
+++ b/cmake/FindWPEWebKit.cmake
@@ -9,7 +9,7 @@
 # So here we purposely left one underscore away
 
 find_package(PkgConfig)
-pkg_check_modules(PC_WPE_WEBKIT wpe-webkit)
+pkg_check_modules(PC_WPE_WEBKIT wpe-webkit-deprecated-0.1)
 
 if(PC_WPE_WEBKIT_FOUND)
     if(WPE_WEBKIT_FIND_VERSION AND PC_WPE_WEBKIT_VERSION)


### PR DESCRIPTION
Fixes needed in order to be able to compile with wpe-2.22 (without GLIB API yet).
The next (separate step) would be to add GLIP API on top of that.