### PR TITLE
[TimeSync] Allow setting the time from an external source

### DIFF
--- a/TimeSync/CMakeLists.txt
+++ b/TimeSync/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(${NAMESPACE}Plugins REQUIRED)
 
 add_library(${MODULE_NAME} SHARED 
     TimeSync.cpp
+    TimeSyncJsonRpc.cpp
     NTPClient.cpp
     Module.cpp)
 

--- a/TimeSync/TimeSync.cpp
+++ b/TimeSync/TimeSync.cpp
@@ -10,8 +10,6 @@ namespace Plugin {
     static Core::ProxyPoolType<Web::JSONBodyType<TimeSync::Data<>>> jsonResponseFactory(4);
 
     static const uint16_t NTPPort = 123;
-    static constexpr auto* kTimeMethodName = _T("time");
-    static constexpr auto* kSyncMethodName = _T("synchronize");
 
 #ifdef __WIN32__
 #pragma warning(disable : 4355)
@@ -23,8 +21,7 @@ namespace Plugin {
         , _activity(Core::ProxyType<PeriodicSync>::Create(_client))
         , _sink(this)
     {
-        Register<void, Data<Core::JSON::DecUInt64>>(kTimeMethodName, &TimeSync::time, this);
-        Register<void, void>(kSyncMethodName, &TimeSync::synchronize, this);
+        RegisterAll();
     }
 #ifdef __WIN32__
 #pragma warning(default : 4355)
@@ -32,8 +29,7 @@ namespace Plugin {
 
     /* virtual */ TimeSync::~TimeSync()
     {
-        Unregister(kTimeMethodName);
-        Unregister(kSyncMethodName);
+        UnregisterAll();
         _client->Release();
     }
 
@@ -49,7 +45,12 @@ namespace Plugin {
 
         static_cast<NTPClient*>(_client)->Initialize(index, config.Retries.Value(), config.Interval.Value());
 
-        _sink.Initialize(service, _client);
+        ASSERT(service != nullptr);
+        ASSERT(_service == nullptr);
+        _service = service;
+        _service->AddRef();
+
+        _sink.Initialize(_client);
 
         // On success return empty, to indicate there is no error text.
         return _T("");
@@ -59,6 +60,10 @@ namespace Plugin {
     {
         PluginHost::WorkerPool::Instance().Revoke(_activity);
         _sink.Deinitialize();
+
+        ASSERT(_service != nullptr);
+        _service->Release();
+        _service = nullptr;
     }
 
     /* virtual */ string TimeSync::Information() const
@@ -84,6 +89,8 @@ namespace Plugin {
         result->ErrorCode = Web::STATUS_OK;
         result->Message = "OK";
 
+        index.Next();
+
         if (request.Verb == Web::Request::HTTP_GET) {
             Core::ProxyType<Web::JSONBodyType<Data<>>> response(jsonResponseFactory.Element());
             uint64_t syncTime(_client->SyncTime());
@@ -94,10 +101,29 @@ namespace Plugin {
             result->ContentType = Web::MIMETypes::MIME_JSON;
             result->Body(Core::proxy_cast<Web::IBody>(response));
         } else if (request.Verb == Web::Request::HTTP_POST) {
-
-            if (index.Next()) {
+            if (index.IsValid() && index.Next()) {
                 if (index.Current() == "Sync") {
                     _client->Synchronize();
+                } else if (index.Current() == "Set") {
+                    if (index.Next()) {
+                        Core::Time newTime(std::stoll(index.Current().Text()));
+                        if (newTime.IsValid()) {
+                            Core::SystemInfo::Instance().SetTime(newTime);
+                        }
+                        else {
+                            result->ErrorCode = Web::STATUS_BAD_REQUEST;
+                            result->Message = _T("Invalid time.");
+                        }
+                    }
+
+                    if (result->ErrorCode == Web::STATUS_OK) {
+                        EnsureSubsystemIsActive();
+                    }
+                }
+                else
+                {
+                    result->ErrorCode = Web::STATUS_BAD_REQUEST;
+                    result->Message = _T("Unknown POST request for the [TimeSync] service.");
                 }
             }
         } else {
@@ -127,16 +153,18 @@ namespace Plugin {
         }
     }
 
-    uint32_t TimeSync::time(Data<Core::JSON::DecUInt64>& response)
+    void TimeSync::EnsureSubsystemIsActive()
     {
-        response.TimeSource = _client->Source();
-        response.SyncTime = _client->SyncTime();
-        return Core::ERROR_NONE;
-    }
+        PluginHost::ISubSystem* subSystem = _service->SubSystems();
+        ASSERT(subSystem != nullptr);
 
-    uint32_t TimeSync::synchronize()
-    {
-        return _client->Synchronize();
+        if (subSystem != nullptr) {
+            if (subSystem->IsActive(PluginHost::ISubSystem::TIME) == false) {
+                subSystem->Set(PluginHost::ISubSystem::TIME, _client);
+            }
+
+            subSystem->Release();
+        }
     }
 
 } // namespace Plugin

--- a/TimeSync/TimeSync.cpp
+++ b/TimeSync/TimeSync.cpp
@@ -85,9 +85,8 @@ namespace Plugin {
             false,
             '/');
 
-        // By default, we assume everything works..
-        result->ErrorCode = Web::STATUS_OK;
-        result->Message = "OK";
+        result->ErrorCode = Web::STATUS_BAD_REQUEST;
+        result->Message = "Unsupported request for the TimeSync service";
 
         index.Next();
 
@@ -100,11 +99,22 @@ namespace Plugin {
 
             result->ContentType = Web::MIMETypes::MIME_JSON;
             result->Body(Core::proxy_cast<Web::IBody>(response));
+            result->ErrorCode = Web::STATUS_OK;
+            result->Message = "OK";
         } else if (request.Verb == Web::Request::HTTP_POST) {
             if (index.IsValid() && index.Next()) {
                 if (index.Current() == "Sync") {
                     _client->Synchronize();
-                } else if (index.Current() == "Set") {
+                    result->ErrorCode = Web::STATUS_OK;
+                    result->Message = "OK";
+                }
+            }
+        } else if (request.Verb == Web::Request::HTTP_PUT) {
+            if (index.IsValid() && index.Next()) {
+                if (index.Current() == "Set") {
+                    result->ErrorCode = Web::STATUS_OK;
+                    result->Message = "OK";
+
                     if (index.Next()) {
                         Core::Time newTime(std::stoll(index.Current().Text()));
                         if (newTime.IsValid()) {
@@ -120,15 +130,7 @@ namespace Plugin {
                         EnsureSubsystemIsActive();
                     }
                 }
-                else
-                {
-                    result->ErrorCode = Web::STATUS_BAD_REQUEST;
-                    result->Message = _T("Unknown POST request for the [TimeSync] service.");
-                }
             }
-        } else {
-            result->ErrorCode = Web::STATUS_BAD_REQUEST;
-            result->Message = _T("Unsupported request for the [TimeSync] service.");
         }
 
         return result;

--- a/TimeSync/TimeSync.h
+++ b/TimeSync/TimeSync.h
@@ -3,6 +3,7 @@
 
 #include "Module.h"
 #include <interfaces/ITimeSync.h>
+#include <interfaces/json/JsonData_TimeSync.h>
 
 namespace WPEFramework {
 namespace Plugin {
@@ -44,7 +45,6 @@ namespace Plugin {
             explicit Notification(TimeSync* parent)
                 : _adminLock()
                 , _parent(*parent)
-                , _service(nullptr)
                 , _client(nullptr)
             {
                 ASSERT(parent != nullptr);
@@ -54,18 +54,13 @@ namespace Plugin {
             }
 
         public:
-            void Initialize(PluginHost::IShell* service, Exchange::ITimeSync* client)
+            void Initialize(Exchange::ITimeSync* client)
             {
-                ASSERT(_service == nullptr);
-                ASSERT(service != nullptr);
                 ASSERT(_client == nullptr);
                 ASSERT(client != nullptr);
 
                 _client = client;
                 _client->AddRef();
-
-                _service = service;
-                _service->AddRef();
 
                 _client->Synchronize();
                 _client->Register(this);
@@ -73,7 +68,6 @@ namespace Plugin {
             void Deinitialize()
             {
 
-                ASSERT(_service != nullptr);
                 ASSERT(_client != nullptr);
 
                 if (_client != nullptr) {
@@ -81,9 +75,6 @@ namespace Plugin {
                     _client->Release();
                     _client = nullptr;
                 }
-
-                _service->Release();
-                _service = nullptr;
             }
 
             virtual void Completed()
@@ -92,17 +83,7 @@ namespace Plugin {
 
                 if (timeTicks != 0) {
                     _parent.SyncedTime(timeTicks);
-                    // On activation subscribe, on deactivation un-subscribe
-                    PluginHost::ISubSystem* subSystem = _service->SubSystems();
-
-                    ASSERT(subSystem != nullptr);
-
-                    if (subSystem != nullptr) {
-                        if (subSystem->IsActive(PluginHost::ISubSystem::TIME) == false) {
-                            subSystem->Set(PluginHost::ISubSystem::TIME, _client);
-                        }
-                        subSystem->Release();
-                    }
+                    _parent.EnsureSubsystemIsActive();
                 }
             }
 
@@ -113,7 +94,6 @@ namespace Plugin {
         private:
             Core::CriticalSection _adminLock;
             TimeSync& _parent;
-            PluginHost::IShell* _service;
             Exchange::ITimeSync* _client;
         };
 
@@ -205,8 +185,14 @@ namespace Plugin {
 
     private:
         void SyncedTime(const uint64_t timeTicks);
-        uint32_t time(Data<Core::JSON::DecUInt64>& data);
-        uint32_t synchronize();
+        void EnsureSubsystemIsActive();
+
+        // JSON RPC
+        void RegisterAll();
+        void UnregisterAll();
+        uint32_t endpoint_time(JsonData::TimeSync::TimeResultData& response);
+        uint32_t endpoint_synchronize();
+        uint32_t endpoint_set(const JsonData::TimeSync::SetParamsData& params);
 
     private:
         uint16_t _skipURL;
@@ -214,6 +200,7 @@ namespace Plugin {
         Exchange::ITimeSync* _client;
         Core::ProxyType<Core::IDispatchType<void>> _activity;
         Core::Sink<Notification> _sink;
+        PluginHost::IShell* _service;
     };
 
 } // namespace Plugin

--- a/TimeSync/TimeSync.h
+++ b/TimeSync/TimeSync.h
@@ -34,6 +34,27 @@ namespace Plugin {
             TimeRep SyncTime;
         };
 
+        template <typename TimeRep = Core::JSON::String>
+        class SetData : public Core::JSON::Container {
+        public:
+            SetData(SetData const& other) = delete;
+            SetData& operator=(SetData const& other) = delete;
+
+            SetData()
+                : Core::JSON::Container()
+                , Time()
+            {
+                Add(_T("time"), &Time);
+            }
+
+            virtual ~SetData()
+            {
+            }
+
+        public:
+            TimeRep Time;
+        };
+
     private:
         class Notification : protected Exchange::ITimeSync::INotification {
         private:

--- a/TimeSync/TimeSyncJsonRpc.cpp
+++ b/TimeSync/TimeSyncJsonRpc.cpp
@@ -34,8 +34,10 @@ namespace Plugin {
     //  - ERROR_NONE: Success
     uint32_t TimeSync::endpoint_time(TimeResultData& response)
     {
-        response.Time =  _client->SyncTime();
-        response.Source = _client->Source();
+        response.Time = Core::Time(_client->SyncTime()).ToISO8601(/* local */ true);
+        if (response.Time.Value().length() != 0) {
+            response.Source = _client->Source();
+        }
 
         return Core::ERROR_NONE;
     }
@@ -65,8 +67,10 @@ namespace Plugin {
         uint32_t result = Core::ERROR_NONE;
 
         if (params.Time.IsSet()) {
-            const uint64_t& time = params.Time.Value();
-            Core::Time newTime(time);
+            const string& time = params.Time.Value();
+            Core::Time newTime(0);
+            newTime.FromISO8601(time);
+
             if (newTime.IsValid()) {
                 Core::SystemInfo::Instance().SetTime(newTime);
             }

--- a/TimeSync/TimeSyncJsonRpc.cpp
+++ b/TimeSync/TimeSyncJsonRpc.cpp
@@ -1,0 +1,88 @@
+
+#include <interfaces/json/JsonData_TimeSync.h>
+#include "TimeSync.h"
+#include "Module.h"
+
+namespace WPEFramework {
+
+namespace Plugin {
+
+    using namespace JsonData::TimeSync;
+
+    // Registration
+    //
+
+    void TimeSync::RegisterAll()
+    {
+        Register<void,TimeResultData>(_T("time"), &TimeSync::endpoint_time, this);
+        Register<void,void>(_T("synchronize"), &TimeSync::endpoint_synchronize, this);
+        Register<SetParamsData,void>(_T("set"), &TimeSync::endpoint_set, this);
+    }
+
+    void TimeSync::UnregisterAll()
+    {
+        Unregister(_T("set"));
+        Unregister(_T("synchronize"));
+        Unregister(_T("time"));
+    }
+
+    // API implementation
+    //
+
+    // Returns the synchronized time.
+    // Return codes:
+    //  - ERROR_NONE: Success
+    uint32_t TimeSync::endpoint_time(TimeResultData& response)
+    {
+        response.Time =  _client->SyncTime();
+        response.Source = _client->Source();
+
+        return Core::ERROR_NONE;
+    }
+
+    // Synchronizes time.
+    // Return codes:
+    //  - ERROR_NONE: Success
+    //  - ERROR_INPROGRESS: Operation in progress
+    //  - Core: Returned when the source configuration is missing or invalid.
+    uint32_t TimeSync::endpoint_synchronize()
+    {
+        uint32_t result = _client->Synchronize();
+
+        if ((result != Core::ERROR_NONE) && (result != Core::ERROR_INPROGRESS) && (result != Core::ERROR_INCOMPLETE_CONFIG)) {
+            result = Core::ERROR_INCOMPLETE_CONFIG;
+        }
+
+        return result;
+    }
+
+    // Sets the current time from an external source.
+    // Return codes:
+    //  - ERROR_NONE: Success
+    //  - ERROR_BAD_REQUEST: Returned when the requested time was invalid
+    uint32_t TimeSync::endpoint_set(const SetParamsData& params)
+    {
+        uint32_t result = Core::ERROR_NONE;
+
+        if (params.Time.IsSet()) {
+            const uint64_t& time = params.Time.Value();
+            Core::Time newTime(time);
+            if (newTime.IsValid()) {
+                Core::SystemInfo::Instance().SetTime(newTime);
+            }
+            else {
+                result = Core::ERROR_BAD_REQUEST;
+            }
+        }
+
+        if (result == Core::ERROR_NONE) {
+            EnsureSubsystemIsActive();
+        }
+
+        return result;
+    }
+
+} // namespace Plugin
+
+}
+


### PR DESCRIPTION
- Modify the JSON-RPC implementation of TimeSync plugin to use the autogenerated files
- Add new "set" method to JSON-RPC and RESTful  interfaces to allowing setting of time from an external source
- Fix not-working RESTful "sync" call
