### PR TITLE
Fix cmake error

### DIFF
--- a/OpenCDMi/CMakeLists.txt
+++ b/OpenCDMi/CMakeLists.txt
@@ -32,10 +32,10 @@ install(TARGETS ${MODULE_NAME}
 
 if("${CMAKE_FIND_ROOT_PATH}" STREQUAL "")
    # Desktop case: not cross compiling
-   target_link_libraries(${MODULE_NAME} "${CMAKE_INSTALL_PREFIX}/lib/libocdm.so")
+   target_link_libraries(${MODULE_NAME} PRIVATE "${CMAKE_INSTALL_PREFIX}/lib/libocdm.so")
 else()
    # Cross compiling: buildroot
-   target_link_libraries(${MODULE_NAME} ${PLUGINS_LIBRARIES} ${OCDM_LIBRARIES})
+   target_link_libraries(${MODULE_NAME} PRIVATE ${PLUGINS_LIBRARIES} ${OCDM_LIBRARIES})
 endif()
 
 # Library installation section


### PR DESCRIPTION
Fixes the following error:
CMake Error at OpenCDMi/CMakeLists.txt:34 (target_link_libraries):
  The keyword signature for target_link_libraries has already been used with
  the target "WPEFrameworkOCDM".  All uses of target_link_libraries with a
  target must be either all-keyword or all-plain.

  The uses of the keyword signature are here:

   * OpenCDMi/CMakeLists.txt:24 (target_link_libraries)